### PR TITLE
Updates to run using rf/ion/mesa branch

### DIFF
--- a/step1_HMS-HMS/clean
+++ b/step1_HMS-HMS/clean
@@ -1,0 +1,2 @@
+cd make
+make clean

--- a/step1_HMS-HMS/inlist
+++ b/step1_HMS-HMS/inlist
@@ -1,0 +1,25 @@
+
+&binary_job
+
+      read_extra_binary_job_inlist(1) = .true.
+      extra_binary_job_inlist_name(1) = 'inlist_project'
+
+/ ! end of star_job namelist
+
+
+
+&binary_controls
+
+      read_extra_binary_controls_inlist(1) = .true.
+      extra_binary_controls_inlist_name(1) = 'inlist_project'
+
+/ ! end of controls namelist
+
+
+
+&pgbinary
+
+      read_extra_pgbinary_inlist(1) = .true.
+      extra_pgbinary_inlist_name(1) = 'inlist_project'
+
+/ ! end of pgbinary namelist

--- a/step1_HMS-HMS/inlist1
+++ b/step1_HMS-HMS/inlist1
@@ -1,0 +1,523 @@
+!default inlist
+
+&star_job
+      show_log_description_at_start = .false.
+
+      write_profile_when_terminate = .false. !this is done in the run_binary_extras.f
+      !save_model_number = 1 ! taken care at run_binary_extras.f
+
+      save_model_when_terminate = .true.
+      save_model_filename = 'model1.mod' ! name get changed from Scotti's script
+
+
+      ! set initial age and model number to 0 again
+      set_initial_age = .true.
+      initial_age = 0.0d0
+      set_initial_model_number = .true.
+      initial_model_number = 0
+
+      !OPACITY, NETWORK, RATE, etc.
+      !network
+      change_net = .true.
+      new_net_name = 'approx21.net'
+      show_net_species_info = .true.
+
+      !relax_tau_factor = .true.
+      !relax_to_this_tau_factor = 10d0
+      !dlogtau_factor = 0.05d0
+
+      new_rotation_flag = .true.
+      change_rotation_flag = .true.
+      set_initial_surface_rotation_v = .true.
+      new_surface_rotation_v = 0.0d0
+      num_steps_to_relax_rotation = 50
+
+      !use jina
+      !set_rates_preference = .true.
+      !new_rates_preference = 2
+      pgstar_flag = .true.
+
+/ ! end of star_job namelist
+
+&eos
+      !EOS
+      eosDT_use_linear_interp_for_X = .false.
+      eosDT_use_linear_interp_to_HELM = .false.
+
+      use_PC = .true.
+      mass_fraction_limit_for_PC = 1d-3
+      logRho1_PC_limit = 2.999d0
+      logRho2_PC_limit = 2.8d0
+      log_Gamma_e_all_HELM = 1.0d0
+      log_Gamma_e_all_PC = 1.3010299956d0
+
+/ ! end of eos namelist
+
+&kap
+      Zbase = 1.42d-2
+
+      use_Type2_opacities = .true.
+      kap_Type2_full_off_X = 1.0d-3
+      kap_Type2_full_on_X = 1.0d-6
+      cubic_interpolation_in_X = .true.
+      cubic_interpolation_in_Z = .true.
+
+      !logQ_max_FreeEOS_hi = 5.6d0
+/ ! end of kap namelist
+
+&controls
+      zams_filename = './zams_z1.42m2_y0.2703.data' !POSYDON ZAMS files
+      initial_z = 1.42d-2
+      initial_y = 2.7029999999999998D-01
+
+      warn_when_large_rel_run_E_err = 1d99
+      !warn_when_stop_checking_residuals = .false.
+
+      use_gold_tolerances = .false.
+      !use_dedt_form_of_energy_eqn = .false.
+      !use_eosELM = .false.
+      !use_eosDT2 = .false.
+
+      !OUTPUT OPTIONS
+      photo_directory = 'photos1'
+      log_directory = 'LOGS1'
+      history_interval = 1
+      terminal_interval = 10
+      write_header_frequency = 100
+      photo_digits = 5
+      photo_interval = 0
+
+      ! H core overshoot !NEW OVERSHOOTING
+      overshoot_scheme(1) = 'exponential'
+      overshoot_zone_type(1) = 'any' ! 'burn_H'
+      overshoot_zone_loc(1) = 'core'
+      overshoot_bdy_loc(1) = 'any'
+
+      overshoot_f(1) = 4.15d-2
+      overshoot_f0(1) = 8.0d-3
+
+      star_history_dbl_format = '(1pes32.16e3, 1x)'
+      star_history_int_format = '(i32, 1x)'
+      star_history_txt_format = '(a32, 1x)'
+
+      star_history_name = 'history.data'
+      write_profiles_flag = .false.
+
+      !WHEN TO STOP
+      gamma_center_limit = 10d0 ! Crystallization begins ==> white dwarf
+      max_age = 1.4e10 ! Hubble time
+
+      !PHYSICS
+      !which_atm_option = 'simple_photosphere'
+      !which_atm_off_table_option = 'simple_photosphere'
+      Pextra_factor = 2.0d0
+
+      !CONVECTION + MIXING
+      do_conv_premix = .true.
+      conv_premix_avoid_increase = .true.
+
+      mixing_length_alpha = 1.93d0
+      mlt_option = 'Mihalas'
+      mlt_use_rotation_correction = .false.
+      okay_to_reduce_gradT_excess = .true.
+
+      use_ledoux_criterion = .true.
+      alpha_semiconvection = 0d0
+      thermohaline_coeff = 17.5d0 ! 2/3 * 8/3 * pi^2 for aspect ratio 1 of the fingers, using eq. 4 of Charbonel+2007 and eq. 14 in Paxton+2013
+      mixing_D_limit_for_log = 1d-50
+      num_cells_for_smooth_gradL_composition_term = 0
+
+      !ROTATION
+      !fitted_fp_ft_i_rot = .true.
+      w_div_wcrit_max = 0.9d0
+
+      max_mdot_redo_cnt = 200 !DEF: 0 (explicit).
+      surf_avg_tau_min = 0.0 !DEF: 1
+      surf_avg_tau = 10.0 !DEF: 100
+      min_years_dt_for_redo_mdot = 0.0 !DEF:0
+      surf_omega_div_omega_crit_limit = 0.99d0 !DEF:0.99
+      surf_omega_div_omega_crit_tol = 0.05d0 !DEF:0.05
+      rotational_mdot_boost_fac = 1d10 !DEF:1d5
+      rotational_mdot_kh_fac = 1d10 !DEF: 0.3d0
+      mdot_revise_factor = 1.2d0 !DEF:1.1
+      implicit_mdot_boost = 0.1d0 !DEF:0.1
+      max_mdot_jump_for_rotation = 10.0d0  ! for smooth transition from mass accretion to mass loss
+
+      D_visc_factor = 0.0d0
+      D_ST_factor = 0.0d0
+      D_SH_factor = 0.0d0 !this is different from MIST2
+      D_GSF_factor = 1.0d0
+      D_ES_factor = 1.0d0
+      D_SSI_factor = 1.0d0
+      D_DSI_factor = 1.0d0
+      am_D_mix_factor = 0.0333333d0 ! f_c in Heger+2000
+      am_gradmu_factor = 0.05d0 !f_mu = 0.05 in Heger+2000, 0.1 in Yoon+2006
+
+      am_nu_ST_factor = 1.0d0 ! 0:noTS, 1:TS
+      use_other_am_mixing = .true. ! use this if you want to use the enhanced FULLER et al. TAYLER-SPRUIT
+      !am_time_average = .true.
+      premix_omega = .true.
+      recalc_mixing_info_each_substep = .true.
+      am_nu_factor = 1.0d0
+      am_nu_non_rotation_factor = 1.0d0
+      am_nu_visc_factor = 0.333d0 !
+      !angsml = 0.0d0 !
+
+      !MASS LOSS
+      use_other_wind=.true. ! combination of Dutch and Reimers, with Z=Zbase for the scaling
+      cool_wind_full_on_T = 0.8d4
+      hot_wind_full_on_T = 1.2d4
+      RGB_to_AGB_wind_switch = 1.0d-4
+      hot_wind_scheme = 'Dutch' ! hot of all stars
+      cool_wind_RGB_scheme ='Dutch'  ! cool of high mass stars (Minit>10Msun),
+           !it gets replaced in run_star_extras by 'Reimers' for cool low mass stars
+      cool_wind_AGB_scheme = 'Blocker' ! cool for low mass stars in AGB
+      Dutch_scaling_factor = 1.0d0
+      Blocker_scaling_factor = 0.2d0
+      Reimers_scaling_factor = 0.1d0
+      !max_wind = 1.0d-3 ! different from MIST2, to allow mass transfer and mass loss > 10^-3 Msun/yr
+
+      !DIFFUSION
+      do_element_diffusion = .false. ! different from MIST2
+      diffusion_dt_limit = 3.15d9 !seconds
+      diffusion_min_T_at_surface = 1.0d3
+      diffusion_min_dq_at_surface = 1.0d-3
+      diffusion_gamma_full_on = 165d0
+      diffusion_gamma_full_off = 175d0
+      diffusion_use_full_net = .true.
+      !do_Ne22_sedimentation_heating = .true.
+
+      !CORE MASS DEFINITION
+      he_core_boundary_h1_fraction = 1d-2
+      co_core_boundary_he4_fraction = 1d-1
+      one_core_boundary_he4_c12_fraction = 1d-1
+      min_boundary_fraction = 1d-1
+
+      !MESH AND TIMESTEP PARAMETERS
+      mesh_delta_coeff = 1.0d0
+      !convective_bdy_weight = 0.5d0
+      varcontrol_target = 1d-3
+      max_timestep_factor = 1.2d0
+      max_allowed_nz = 20000
+      max_dq = 2d-3
+
+      solver_iters_timestep_limit = 20
+
+      delta_XH_cntr_limit = 0.005d0
+      delta_XH_cntr_hard_limit = -1
+
+      delta_XHe_cntr_limit = 0.01d0
+      delta_XHe_cntr_hard_limit = -1
+
+      delta_XC_cntr_limit = 0.002d0
+      delta_XC_cntr_hard_limit = -1
+
+      !better resolution of the Henyey hook
+      !delta_lg_XH_cntr_max = -1.0d0
+      !delta_lg_XH_cntr_min = -3.0d0
+      !delta_lg_XH_cntr_limit = 0.1d0
+      !delta_lg_XH_cntr_hard_limit = -1
+
+      !delta_lg_XHe_cntr_max = -1.0d0
+      !delta_lg_XHe_cntr_min = -3.0d0
+      !delta_lg_XHe_cntr_limit = 0.1d0
+      !delta_lg_XHe_cntr_hard_limit = -1
+
+      ! From Frank's suggestions
+      delta_lgT_cntr_limit   = 0.005d0   ! default 0.01
+      delta_lgT_limit = 0.025d0         ! default 0.5
+      delta_lgRho_cntr_limit = 0.025d0   ! default 0.05
+      delta_lgRho_limit = 0.5d0          ! default 1.0
+
+      delta_lgL_He_limit = 0.1d0
+
+      ! time step resolution on fuel depletion
+      !delta_lg_XH_cntr_limit = 0.01d0
+      !delta_lg_XH_cntr_max   = 0.0d0
+      !delta_lg_XH_cntr_min   = -4.0d0
+      !delta_lg_XH_cntr_hard_limit = 0.02d0
+      delta_lg_XHe_cntr_limit = 0.01d0
+      delta_lg_XHe_cntr_max   = 0.0d0
+      delta_lg_XHe_cntr_min   = -4.0d0
+      delta_lg_XHe_cntr_hard_limit = 0.02d0
+      delta_lg_XC_cntr_limit = 0.01d0
+      delta_lg_XC_cntr_max   = 0.0d0
+      delta_lg_XC_cntr_min   = -2.0d0 ! -3.0d0
+      delta_lg_XC_cntr_hard_limit = 0.02d0
+      delta_lg_XO_cntr_limit = 0.01d0
+      delta_lg_XO_cntr_max   = 0.0d0
+      delta_lg_XO_cntr_min   = -3.0d0
+      delta_lg_XO_cntr_hard_limit = 0.02d0
+
+! limit changes in the timestep
+     timestep_factor_for_retries = 0.75d0
+
+! HRD, Radius resolution
+delta_HR_ds_L = 0.125d0
+ delta_HR_ds_Teff = 2.0d0
+    !### delta_HR_limit
+    !### delta_HR_hard_limit
+    ! limit for dHR (negative means no limit)
+    !     dHR = sqrt((delta_HR_ds_L*dlgL)**2 + (delta_HR_ds_Teff*dlgTeff)**2)
+ delta_HR_limit = 0.1d0
+ delta_HR_hard_limit = 0.2d0
+
+      ! for single stars stars, the control below needs to be true, so that the carbon exhaustion check happens in run_star_extras.f
+      x_logical_ctrl(1) = .false.
+      ! for formation of He single stars, before they later evolve in a CO-HeMS binary or in a He Star
+      x_logical_ctrl(2) = .false.
+      ! Turn on eq.8 Belczynski+2010 LBV2 winds  with factor 1 (10-4 Msun/yr) to replace other winds for postMS stars in Humphreys-Davidson limit
+      x_logical_ctrl(3) = .false.
+
+/ ! end of controls namelist
+
+&pgstar
+    ! pause = .true.
+    pgstar_show_age_in_years = .true. 
+    pgstar_show_title = .false.
+
+    ! *********************************
+    ! ***** general grid controls *****
+    ! *********************************
+             
+    !file_white_on_black_flag = .false.
+    !win_white_on_black_flag = .false.
+    Grid2_win_flag = .true.
+    Grid2_num_cols = 16 ! divide plotting region into this many equal width cols
+    Grid2_num_plots = 8
+    Grid2_num_rows = 9 
+    Grid2_win_width = 16
+    ! Grid2_win_width = 19
+    Grid2_win_aspect_ratio = 0.65 ! aspect_ratio = height/width
+    Grid2_xleft = 0.04 ! fraction of full window width for margin on left
+    Grid2_xright = 0.96 ! fraction of full window width for margin on right
+    Grid2_ybot = 0.02 ! fraction of full window width for margin on bottom
+    Grid2_ytop = 0.95 ! fraction of full window width for margin on top
+    Grid2_file_flag = .true.
+    Grid2_file_dir = 'png2'
+    Grid2_file_prefix = 'Grid2'
+    Grid2_file_interval = 30 
+    Grid2_file_width = 21
+    Grid2_file_aspect_ratio = 0.6
+
+
+    ! ***********************************
+    ! ***** central conditions plot *****
+    ! ***********************************
+    Grid2_plot_name(1) = 'TRho_Profile'
+    Grid2_plot_row(1) = 7
+    Grid2_plot_rowspan(1) = 3
+    Grid2_plot_col(1) = 9 
+    Grid2_plot_colspan(1) = 3 
+    Grid2_plot_pad_left(1) = 0.0
+    Grid2_plot_pad_right(1) = 0.0
+    Grid2_plot_pad_top(1) = 0.06
+    Grid2_plot_pad_bot(1) = 0.03
+    Grid2_txt_scale_factor(1) = 0.5 
+    show_TRho_Profile_legend = .true.      
+    show_TRho_Profile_eos_regions = .true.=.false.
+    show_TRho_annotation1 = .true.
+    show_TRho_annotation2 = .true.
+    show_TRho_annotation3 = .true.
+    show_TRho_degeneracy_line = .true.    
+
+ 
+    ! **********************
+    ! ***** HR diagram *****
+    ! **********************
+    Grid2_plot_name(2) = 'HR'
+    Grid2_plot_row(2) = 5
+    Grid2_plot_rowspan(2) = 5
+    Grid2_plot_col(2) = 1
+    Grid2_plot_colspan(2) = 5
+    Grid2_plot_pad_left(2) = 0.0
+    Grid2_plot_pad_right(2) = 0.03
+    Grid2_plot_pad_top(2) = 0.05
+    Grid2_plot_pad_bot(2) = 0.05
+    Grid2_txt_scale_factor(2) = 0.5
+
+
+
+    ! ******************************
+    ! ***** Kippenhahn diagram *****
+    ! ******************************
+
+    Grid2_plot_name(3) = 'Kipp'
+    Grid2_plot_row(3) = 0
+    Grid2_plot_rowspan(3) = 5
+    Grid2_plot_col(3) = 1 
+    Grid2_plot_colspan(3) = 5
+    Grid2_plot_pad_left(3) = 0.00
+    Grid2_plot_pad_right(3) = 0.02
+    Grid2_plot_pad_top(3) = 0.06
+    Grid2_plot_pad_bot(3) = 0.05
+    Grid2_txt_scale_factor(3) = 0.5
+
+    !Grid2_Kipp_show_burn(3) = .true.
+
+
+
+    ! **************************
+    ! ***** Text summaries *****
+    ! **************************
+
+    Grid2_plot_name(4) = 'Text_Summary1'
+    Grid2_plot_row(4) =0 
+    Grid2_plot_rowspan(4) = 3
+    Grid2_plot_col(4) = 6
+    Grid2_plot_colspan(4) = 2
+    Grid2_plot_pad_left(4) = 0.0
+    Grid2_plot_pad_right(4) =0.0
+    Grid2_plot_pad_top(4) = 0.05
+    Grid2_plot_pad_bot(4) = 0.0
+    Grid2_txt_scale_factor(4) = 0.14 
+    Text_Summary1_num_rows = 12
+    Text_Summary1_num_cols = 1
+    Text_Summary1_name(:,:) = ''
+
+    Text_Summary1_name(1,1) = 'model_number'
+    Text_Summary1_name(2,1) = 'log_star_age'
+    Text_Summary1_name(3,1) = 'log_dt'
+    Text_Summary1_name(4,1) = 'num_zones'
+    Text_Summary1_name(5,1) = 'num_retries'
+    ! Text_Summary1_name(6,1) = 'num_backups'
+    Text_Summary1_name(7,1) = 'star_mass'
+    Text_Summary1_name(8,1) = 'log_abs_mdot'
+    Text_Summary1_name(9,1) = 'log_L'
+    Text_Summary1_name(10,1) = 'log_Teff'
+    Text_Summary1_name(11,1) = 'log_R'
+    Text_Summary1_name(12,1) = 'log_g'
+
+    Grid2_plot_name(5) = 'Text_Summary2'
+    Grid2_plot_row(5) =3 
+    Grid2_plot_rowspan(5) = 3
+    Grid2_plot_col(5) = 6
+    Grid2_plot_colspan(5) = 2
+    Grid2_plot_pad_left(5) = 0.0
+    Grid2_plot_pad_right(5) =0.0
+    Grid2_plot_pad_top(5) = 0.05
+    Grid2_plot_pad_bot(5) = 0.0
+    Grid2_txt_scale_factor(5) = 0.14 
+    Text_Summary2_num_rows = 12
+    Text_Summary2_num_cols = 1
+    Text_Summary2_name(:,:) = ''
+
+    Text_Summary2_name(1,1) = 'log_Lnuc'
+    Text_Summary2_name(2,1) = 'log_Lneu'
+    Text_Summary2_name(3,1) = 'log_LHe'
+    Text_Summary2_name(4,1) = 'log_LZ'
+    Text_Summary2_name(5,1) = 'log_cntr_T'
+    Text_Summary2_name(6,1) = 'center_h1'
+    Text_Summary2_name(7,1) = 'center_he4'
+    Text_Summary2_name(8,1) = 'surf_avg_omega_div_omega_crit'
+    Text_Summary2_name(9,1) = 'surf_avg_Lrad_div_Ledd'
+    Text_Summary2_name(10,1) = 'center_c12'
+    Text_Summary2_name(11,1) = 'center_o16'
+    Text_Summary2_name(12,1) = ''
+
+    Grid2_plot_name(6) = 'Text_Summary3'
+    Grid2_plot_row(6) =6 
+    Grid2_plot_rowspan(6) = 3
+    Grid2_plot_col(6) = 6
+    Grid2_plot_colspan(6) = 2
+    Grid2_plot_pad_left(6) = 0.0
+    Grid2_plot_pad_right(6) =0.0
+    Grid2_plot_pad_top(6) = 0.05
+    Grid2_plot_pad_bot(6) = 0.0
+    Grid2_txt_scale_factor(6) = 0.14 
+    Text_Summary3_num_rows = 12
+    Text_Summary3_num_cols = 1
+    Text_Summary3_name(:,:) = ''
+
+    Text_Summary3_name(1,1) = 'surf_avg_omega'
+    Text_Summary3_name(2,1) = 'v_surf'
+    Text_Summary3_name(3,1) = 'log_L_div_Ledd'
+    Text_Summary3_name(4,1) = ''
+    Text_Summary3_name(5,1) = ''
+    Text_Summary3_name(6,1) = ''
+    Text_Summary3_name(7,1) = 'surface_he4'
+    Text_Summary3_name(8,1) = 'surface_n14'
+    Text_Summary3_name(9,1) = 'surface_c12'
+    Text_Summary3_name(10,1) = ''
+    Text_Summary3_name(11,1) = ''
+    Text_Summary3_name(12,1) = ''
+        
+
+        
+
+    ! ****************************
+    ! ***** Internal profiles ****
+    ! ****************************
+
+
+    Grid2_plot_name(7) = 'Profile_Panels3'
+    Grid2_plot_row(7) = 0
+    Grid2_plot_rowspan(7) = 7 
+    Grid2_plot_col(7) =8 
+    Grid2_plot_colspan(7) = 4
+    Grid2_plot_pad_left(7) = 0.05
+    Grid2_plot_pad_right(7) = 0.02
+    Grid2_plot_pad_top(7) = 0.07
+    Grid2_plot_pad_bot(7) = 0.0
+    Grid2_txt_scale_factor(7) = 0.5
+    Abundance_legend_txt_scale_factor = 1.0 
+    Power_legend_txt_scale_factor = 1.0 
+
+    Abundance_use_decorator = .false.
+    Abundance_legend_max_cnt = 0
+    !Abundance_xmin = -6
+    Abundance_log_mass_frac_min = -4 ! only used if < 0
+
+    Profile_Panels3_title = 'Abundance-Power-Mixing'
+    Profile_Panels3_xaxis_name = "zone"
+    Profile_Panels3_num_panels = 4
+    Profile_Panels3_txt_scale = 1.0
+    Profile_Panels3_yaxis_name(1) = 'Abundance'
+    Profile_Panels3_yaxis_name(2) = 'Power'
+    Profile_Panels3_yaxis_name(3) = 'Mixing'
+    Profile_Panels3_yaxis_name(4) = 'v_rot'
+    Profile_Panels3_other_yaxis_name(4) = 'omega_div_omega_crit'
+
+    Profile_Panels3_xaxis_reversed = .false.
+    Profile_Panels3_xmin = 0.0 ! only used if /= -101d0
+    ! Profile_Panels3_xmax = 300
+    Power_use_decorator = .true.
+
+    ! ******************************
+    ! ***** History panels *********
+    ! ******************************
+    Grid2_plot_name(8) = 'History_Panels1'
+    History_Panels1_num_panels = 5
+    History_Panels1_yaxis_name(1) = 'lg_wind_mdot_1'
+    History_Panels1_other_yaxis_name(1) = 'lg_mtransfer_rate'
+    History_Panels1_yaxis_name(2) = 'star_mass'
+    History_Panels1_other_yaxis_name(2) = 'envelope_mass'
+    History_Panels1_yaxis_name(3) = 'radius'
+    History_Panels1_other_yaxis_name(3) = 'rl_2'
+    History_Panels1_yaxis_name(4) = 'v_orb_2'
+    History_Panels1_other_yaxis_name(4) = 'period_days'
+    History_Panels1_yaxis_name(5) = 'surface_he4'
+    History_Panels1_other_yaxis_name(5) = 'surface_n14'
+    History_Panels1_xaxis_name = 'model_number'
+    History_Panels1_yaxis_reversed(:) = .false.
+    History_Panels1_yaxis_log(:) = .false.
+     
+    !History_Panels1_ymin(:) = -15d0
+    !History_Panels1_ymax(:) = 0d0
+    History_Panels1_ymargin(:) = 0.5
+    History_Panels1_dymin(:) = -1
+
+    Grid2_plot_row(8) =0
+    Grid2_plot_rowspan(8) =10 
+    Grid2_plot_col(8) = 13 
+    Grid2_plot_colspan(8) = 4 
+    Grid2_plot_pad_left(8) = 0.02
+    Grid2_plot_pad_right(8) = 0.03
+    Grid2_plot_pad_top(8) = 0.07
+    Grid2_plot_pad_bot(8) = 0.05
+    Grid2_txt_scale_factor(8) = 0.5
+
+      
+/ ! end of pgstar namelist
+
+

--- a/step1_HMS-HMS/inlist2
+++ b/step1_HMS-HMS/inlist2
@@ -1,0 +1,272 @@
+!default inlist
+
+&star_job
+      show_log_description_at_start = .false.
+
+      write_profile_when_terminate = .false. !this is done in the run_binary_extras.f
+      !save_model_number = 1 ! taken care at run_binary_extras.f
+
+      save_model_when_terminate = .true.
+      save_model_filename = 'model2.mod' ! name get changed from Scotti's script
+
+
+      ! set initial age and model number to 0 again
+      set_initial_age = .true.
+      initial_age = 0.0d0
+      set_initial_model_number = .true.
+      initial_model_number = 0
+
+      !OPACITY, NETWORK, RATE, etc.
+      !network
+      change_net = .true.
+      new_net_name = 'approx21.net'
+      show_net_species_info = .true.
+
+      !relax_tau_factor = .true.
+      !relax_to_this_tau_factor = 10d0
+      !dlogtau_factor = 0.05d0
+
+      new_rotation_flag = .true.
+      change_rotation_flag = .true.
+      set_initial_surface_rotation_v = .true.
+      new_surface_rotation_v = 0.0d0
+      num_steps_to_relax_rotation = 50
+
+      !use jina
+      !set_rates_preference = .true.
+      !new_rates_preference = 2
+
+/ ! end of star_job namelist
+
+&eos
+      !EOS
+      eosDT_use_linear_interp_for_X = .false.
+      eosDT_use_linear_interp_to_HELM = .false.
+
+      use_PC = .true.
+      mass_fraction_limit_for_PC = 1d-3
+      logRho1_PC_limit = 2.999d0
+      logRho2_PC_limit = 2.8d0
+      log_Gamma_e_all_HELM = 1.0d0
+      log_Gamma_e_all_PC = 1.3010299956d0
+
+/ ! end of eos namelist
+
+&kap
+      Zbase = 1.42d-2
+
+      use_Type2_opacities = .true.
+      kap_Type2_full_off_X = 1.0d-3
+      kap_Type2_full_on_X = 1.0d-6
+      cubic_interpolation_in_X = .true.
+      cubic_interpolation_in_Z = .true.
+
+      !logQ_max_FreeEOS_hi = 5.6d0
+/ ! end of kap namelist
+
+&controls
+      zams_filename = './zams_z1.42m2_y0.2703.data' !POSYDON ZAMS files
+      initial_z = 1.42d-2
+      initial_y = 2.7029999999999998D-01
+
+      warn_when_large_rel_run_E_err = 1d99
+      !warn_when_stop_checking_residuals = .false.
+
+      use_gold_tolerances = .false.
+      !use_dedt_form_of_energy_eqn = .false.
+      !use_eosELM = .false.
+      !use_eosDT2 = .false.
+
+      !OUTPUT OPTIONS
+      photo_directory = 'photos2'
+      log_directory = 'LOGS2'
+      history_interval = 1
+      terminal_interval = 10
+      write_header_frequency = 100
+      photo_digits = 5
+      photo_interval = 0
+
+      ! H core overshoot !NEW OVERSHOOTING
+      overshoot_scheme(1) = 'exponential'
+      overshoot_zone_type(1) = 'any' ! 'burn_H'
+      overshoot_zone_loc(1) = 'core'
+      overshoot_bdy_loc(1) = 'any'
+
+      overshoot_f(1) = 4.15d-2
+      overshoot_f0(1) = 8.0d-3
+
+      star_history_dbl_format = '(1pes32.16e3, 1x)'
+      star_history_int_format = '(i32, 1x)'
+      star_history_txt_format = '(a32, 1x)'
+
+      star_history_name = 'history.data'
+      write_profiles_flag = .false.
+
+      !WHEN TO STOP
+      gamma_center_limit = 10d0 ! Crystallization begins ==> white dwarf
+      max_age = 1.4e10 ! Hubble time
+
+      !PHYSICS
+      !which_atm_option = 'simple_photosphere'
+      !which_atm_off_table_option = 'simple_photosphere'
+      Pextra_factor = 2.0d0
+
+      !CONVECTION + MIXING
+      do_conv_premix = .true.
+      conv_premix_avoid_increase = .true.
+
+      mixing_length_alpha = 1.93d0
+      mlt_option = 'Mihalas'
+      mlt_use_rotation_correction = .false.
+      okay_to_reduce_gradT_excess = .true.
+
+      use_ledoux_criterion = .true.
+      alpha_semiconvection = 0d0
+      thermohaline_coeff = 17.5d0 ! 2/3 * 8/3 * pi^2 for aspect ratio 1 of the fingers, using eq. 4 of Charbonel+2007 and eq. 14 in Paxton+2013
+      mixing_D_limit_for_log = 1d-50
+      num_cells_for_smooth_gradL_composition_term = 0
+
+      !ROTATION
+      !fitted_fp_ft_i_rot = .true.
+      w_div_wcrit_max = 0.9d0
+
+      max_mdot_redo_cnt = 200 !DEF: 0 (explicit).
+      surf_avg_tau_min = 0.0 !DEF: 1
+      surf_avg_tau = 10.0 !DEF: 100
+      min_years_dt_for_redo_mdot = 0.0 !DEF:0
+      surf_omega_div_omega_crit_limit = 0.99d0 !DEF:0.99
+      surf_omega_div_omega_crit_tol = 0.05d0 !DEF:0.05
+      rotational_mdot_boost_fac = 1d10 !DEF:1d5
+      rotational_mdot_kh_fac = 1d10 !DEF: 0.3d0
+      mdot_revise_factor = 1.2d0 !DEF:1.1
+      implicit_mdot_boost = 0.1d0 !DEF:0.1
+      max_mdot_jump_for_rotation = 10.0d0  ! for smooth transition from mass accretion to mass loss
+
+      D_visc_factor = 0.0d0
+      D_ST_factor = 0.0d0
+      D_SH_factor = 0.0d0 !this is different from MIST2
+      D_GSF_factor = 1.0d0
+      D_ES_factor = 1.0d0
+      D_SSI_factor = 1.0d0
+      D_DSI_factor = 1.0d0
+      am_D_mix_factor = 0.0333333d0 ! f_c in Heger+2000
+      am_gradmu_factor = 0.05d0 !f_mu = 0.05 in Heger+2000, 0.1 in Yoon+2006
+
+      am_nu_ST_factor = 1.0d0 ! 0:noTS, 1:TS
+      !use_other_am_mixing = .true. ! use this if you want to use the enhanced FULLER et al. TAYLER-SPRUIT
+      !am_time_average = .true.
+      premix_omega = .true.
+      recalc_mixing_info_each_substep = .true.
+      am_nu_factor = 1.0d0
+      am_nu_non_rotation_factor = 1.0d0
+      am_nu_visc_factor = 0.333d0 !
+      !angsml = 0.0d0 !
+
+      !MASS LOSS
+      use_other_wind=.true. ! combination of Dutch and Reimers, with Z=Zbase for the scaling
+      cool_wind_full_on_T = 0.8d4
+      hot_wind_full_on_T = 1.2d4
+      RGB_to_AGB_wind_switch = 1.0d-4
+      hot_wind_scheme = 'Dutch' ! hot of all stars
+      cool_wind_RGB_scheme ='Dutch'  ! cool of high mass stars (Minit>10Msun),
+           !it gets replaced in run_star_extras by 'Reimers' for cool low mass stars
+      cool_wind_AGB_scheme = 'Blocker' ! cool for low mass stars in AGB
+      Dutch_scaling_factor = 1.0d0
+      Blocker_scaling_factor = 0.2d0
+      Reimers_scaling_factor = 0.1d0
+      !max_wind = 1.0d-3 ! different from MIST2, to allow mass transfer and mass loss > 10^-3 Msun/yr
+
+      !DIFFUSION
+      do_element_diffusion = .false. ! different from MIST2
+      diffusion_dt_limit = 3.15d9 !seconds
+      diffusion_min_T_at_surface = 1.0d3
+      diffusion_min_dq_at_surface = 1.0d-3
+      diffusion_gamma_full_on = 165d0
+      diffusion_gamma_full_off = 175d0
+      diffusion_use_full_net = .true.
+      !do_Ne22_sedimentation_heating = .true.
+
+      !CORE MASS DEFINITION
+      he_core_boundary_h1_fraction = 1d-2
+      co_core_boundary_he4_fraction = 1d-1
+      one_core_boundary_he4_c12_fraction = 1d-1
+      min_boundary_fraction = 1d-1
+
+      !MESH AND TIMESTEP PARAMETERS
+      mesh_delta_coeff = 1.0d0
+      !convective_bdy_weight = 0.5d0
+      varcontrol_target = 1d-3
+      max_timestep_factor = 1.2d0
+      max_allowed_nz = 20000
+      max_dq = 2d-3
+
+      solver_iters_timestep_limit = 20
+
+      delta_XH_cntr_limit = 0.005d0
+      delta_XH_cntr_hard_limit = -1
+
+      delta_XHe_cntr_limit = 0.01d0
+      delta_XHe_cntr_hard_limit = -1
+
+      delta_XC_cntr_limit = 0.002d0
+      delta_XC_cntr_hard_limit = -1
+
+      !better resolution of the Henyey hook
+      !delta_lg_XH_cntr_max = -1.0d0
+      !delta_lg_XH_cntr_min = -3.0d0
+      !delta_lg_XH_cntr_limit = 0.1d0
+      !delta_lg_XH_cntr_hard_limit = -1
+
+      !delta_lg_XHe_cntr_max = -1.0d0
+      !delta_lg_XHe_cntr_min = -3.0d0
+      !delta_lg_XHe_cntr_limit = 0.1d0
+      !delta_lg_XHe_cntr_hard_limit = -1
+
+      ! From Frank's suggestions
+      delta_lgT_cntr_limit   = 0.005d0   ! default 0.01
+      delta_lgT_limit = 0.025d0         ! default 0.5
+      delta_lgRho_cntr_limit = 0.025d0   ! default 0.05
+      delta_lgRho_limit = 0.5d0          ! default 1.0
+
+      delta_lgL_He_limit = 0.1d0
+
+      ! time step resolution on fuel depletion
+      !delta_lg_XH_cntr_limit = 0.01d0
+      !delta_lg_XH_cntr_max   = 0.0d0
+      !delta_lg_XH_cntr_min   = -4.0d0
+      !delta_lg_XH_cntr_hard_limit = 0.02d0
+      delta_lg_XHe_cntr_limit = 0.01d0
+      delta_lg_XHe_cntr_max   = 0.0d0
+      delta_lg_XHe_cntr_min   = -4.0d0
+      delta_lg_XHe_cntr_hard_limit = 0.02d0
+      delta_lg_XC_cntr_limit = 0.01d0
+      delta_lg_XC_cntr_max   = 0.0d0
+      delta_lg_XC_cntr_min   = -2.0d0 ! -3.0d0
+      delta_lg_XC_cntr_hard_limit = 0.02d0
+      delta_lg_XO_cntr_limit = 0.01d0
+      delta_lg_XO_cntr_max   = 0.0d0
+      delta_lg_XO_cntr_min   = -3.0d0
+      delta_lg_XO_cntr_hard_limit = 0.02d0
+
+! limit changes in the timestep
+     timestep_factor_for_retries = 0.75d0
+
+! HRD, Radius resolution
+delta_HR_ds_L = 0.125d0
+ delta_HR_ds_Teff = 2.0d0
+    !### delta_HR_limit
+    !### delta_HR_hard_limit
+    ! limit for dHR (negative means no limit)
+    !     dHR = sqrt((delta_HR_ds_L*dlgL)**2 + (delta_HR_ds_Teff*dlgTeff)**2)
+ delta_HR_limit = 0.1d0
+ delta_HR_hard_limit = 0.2d0
+
+      ! for single stars stars, the control below needs to be true, so that the carbon exhaustion check happens in run_star_extras.f
+      x_logical_ctrl(1) = .false.
+      ! for formation of He single stars, before they later evolve in a CO-HeMS binary or in a He Star
+      x_logical_ctrl(2) = .false.
+      ! Turn on eq.8 Belczynski+2010 LBV2 winds  with factor 1 (10-4 Msun/yr) to replace other winds for postMS stars in Humphreys-Davidson limit
+      x_logical_ctrl(3) = .false.
+
+/ ! end of controls namelist
+

--- a/step1_HMS-HMS/inlist_project
+++ b/step1_HMS-HMS/inlist_project
@@ -1,0 +1,82 @@
+&binary_job
+
+   inlist_names(1) = 'inlist1'
+   inlist_names(2) = 'inlist2'
+
+   evolve_both_stars = .true.
+
+/ ! end of binary_job namelist
+
+&binary_controls
+
+   m1 = 12.d0
+   m2 = 1.4d0
+   initial_period_in_days = -1d0
+   initial_separation_in_Rsuns = 972d0
+
+
+   !!! output controls
+   history_interval = 1                           ! interval for writing to binary history;                                   default: 5      | save all steps in history
+   append_to_star_history = .true.                ! define whether the binary history is appended to the star's history, too; default: .true. | allows to plot stellar and binary data from same file
+   photo_interval = 50                            ! interval for writing photos;                                              default: 50     | overwrites value in inlist of the components
+   photo_digits = 5                               ! number of digits in photo's filename;                                     default: 3      | overwrites value in inlist of the components
+   terminal_interval = 10                         ! interval for terminal outputs;                                            default: 1      | get less outputs
+   write_header_frequency = 10                    ! frequency to repeat the header every X outputs;                           default: 10     |
+   extra_binary_terminal_output_file = 'out.txt'  ! writes terminal output to this file, too;  
+   
+   do_jdot_mb = .false.
+   do_jdot_missing_wind = .true.
+   do_j_accretion = .true. ! according to De Mink et al. 2013
+
+   mdot_scheme = "contact" ! This switches to 'Kolb' after one of the two stars reaches TAMS
+
+   ! Mass transfer efficiency controls
+   ! Mass transfer is assumed by default as a base conservative, but is capped further in run_binary_extras
+     mass_transfer_alpha = 0d0      ! fraction of mass lost from the vicinity of donor as fast wind
+     mass_transfer_beta = 0d0       ! fraction of mass lost from the vicinity of accretor as fast wind
+     mass_transfer_delta = 0d0      ! fraction of mass lost from circumbinary coplanar toroid
+
+   append_to_star_history = .false.
+   history_interval = 1
+   terminal_interval = 10
+   write_header_frequency = 100
+
+   ! timestep controls
+   fr = 1d-2 !DEF: 1d-1
+   fr_limit = 1d-2 !DEF: 1d-2
+   fr_dt_limit = 5d2 !1d1
+   fa = 5d-3 !DEF: 1d-2
+   fa_hard = 1d-2 !DEF: 2d-2
+   fm = 5d-3 !DEF: 1d-2
+   fj = 8d-3 !DEF: 1d-3
+   fj_hard = 1d-2 !DEF: 1d-2
+   dt_softening_factor = 0.4d0
+
+   limit_retention_by_mdot_edd = .false. ! turned-on for accretion onto compact objects in run_binary_extras
+   implicit_scheme_tolerance = 1d-4
+   max_tries_to_achieve = 200
+   min_change_factor = 1.01d0
+   max_change_factor = 1.2d0
+   initial_change_factor = 1.2d0
+   change_factor_fraction = 0.8d0
+   implicit_lambda = 0.4d0
+
+   min_mdot_for_implicit = 1d-9
+   roche_min_mdot = 1d-10
+   accretor_overflow_terminate = 100d0
+   terminate_if_L2_overflow = .false. ! L2 oveflow check changes between Marchant et al. 2016 and Misra et al. 2020 for MS or postMS star respectively, in run_binary_extras.f
+
+   do_tidal_sync = .true. ! tides are on
+   do_initial_orbit_sync_1 = .true. ! equal initial orbital and stellar spin period
+   do_initial_orbit_sync_2 = .true. ! equal initial orbital and stellar spin period
+
+   use_other_sync_spin_to_orbit = .true. !we decide where to apply the tides. Calls the tidal timescale calculation
+   use_other_tsync = .true. !tidal timescale calculation
+
+   ! If "structure_dependent", then it calculates both timescales for "Hut_rad" (assuming all star radiative)
+   ! and "Hut_conv" (for the most important convective layer in the envelope)
+   ! and picks the shortest one.
+   sync_type_1 = "structure_dependent"
+   sync_type_2 = "structure_dependent"
+
+/ ! end of binary_controls namelist

--- a/step1_HMS-HMS/make/makefile
+++ b/step1_HMS-HMS/make/makefile
@@ -1,0 +1,7 @@
+ifeq ($(MESA_DIR),)
+ifeq ($($MESA_DIR_INTENTIONALLY_EMPTY),)
+  $(error MESA_DIR enviroment variable is not set)
+endif
+endif
+
+include $(MESA_DIR)/binary/work_standard_makefile_binary

--- a/step1_HMS-HMS/mk
+++ b/step1_HMS-HMS/mk
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+function check_okay {
+	if [ $? -ne 0 ]
+	then
+		echo
+		echo "FAILED"
+		echo
+		exit 1
+	fi
+}
+
+cd make; make; check_okay

--- a/step1_HMS-HMS/re
+++ b/step1_HMS-HMS/re
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+function check_okay {
+	if [ $? -ne 0 ]
+	then
+		exit 1
+	fi
+}
+if [ $1 ]
+then
+    echo $1 > .restart
+fi
+check_okay
+date "+DATE: %Y-%m-%d%nTIME: %H:%M:%S"
+if [[ -e binary.exe ]];then
+	./binary.exe
+else
+	./binary
+fi
+date "+DATE: %Y-%m-%d%nTIME: %H:%M:%S"
+
+

--- a/step1_HMS-HMS/rn
+++ b/step1_HMS-HMS/rn
@@ -1,0 +1,9 @@
+rm -f .restart
+
+date "+DATE: %Y-%m-%d%nTIME: %H:%M:%S"
+if [[ -e binary.exe ]];then
+	./binary.exe
+else
+	./binary
+fi
+date "+DATE: %Y-%m-%d%nTIME: %H:%M:%S"

--- a/step1_HMS-HMS/src/binary_run.f90
+++ b/step1_HMS-HMS/src/binary_run.f90
@@ -1,0 +1,6 @@
+      program binary_run
+      use run_binary, only: do_run_binary
+      
+      call do_run_binary(.true.)
+      
+      end program

--- a/step1_HMS-HMS/src/run_binary_extras.f90
+++ b/step1_HMS-HMS/src/run_binary_extras.f90
@@ -1,0 +1,1181 @@
+! ***********************************************************************
+!
+!   Copyright (C) 2012  Bill Paxton
+!
+!   this file is part of mesa.
+!
+!   mesa is free software; you can redistribute it and/or modify
+!   it under the terms of the gnu general library public license as published
+!   by the free software foundation; either version 2 of the license, or
+!   (at your option) any later version.
+!
+!   mesa is distributed in the hope that it will be useful,
+!   but without any warranty; without even the implied warranty of
+!   merchantability or fitness for a particular purpose.  see the
+!   gnu library general public license for more details.
+!
+!   you should have received a copy of the gnu library general public license
+!   along with this software; if not, write to the free software
+!   foundation, inc., 59 temple place, suite 330, boston, ma 02111-1307 usa
+!
+! ***********************************************************************
+      module run_binary_extras
+
+         use star_lib
+         use star_def
+         use const_def
+         use const_def
+         use chem_def
+         use num_lib
+         use binary_def
+         use math_lib !use crlibm_lib
+         use utils_lib
+
+         USE, INTRINSIC :: IEEE_ARITHMETIC ! isnan() was not working
+
+
+   
+         implicit none
+   
+         contains
+   
+         subroutine extras_binary_controls(binary_id, ierr)
+            integer :: binary_id
+            integer, intent(out) :: ierr
+            type (binary_info), pointer :: b
+            ierr = 0
+   
+            call binary_ptr(binary_id, b, ierr)
+            if (ierr /= 0) then
+               write(*,*) 'failed in binary_ptr'
+               return
+            end if
+   
+            ! Set these function pinters to point to the functions you wish to use in
+            ! your run_binary_extras. Any which are not set, default to a null_ version
+            ! which does nothing.
+            b% how_many_extra_binary_history_columns => how_many_extra_binary_history_columns
+            b% data_for_extra_binary_history_columns => data_for_extra_binary_history_columns
+   
+            b% extras_binary_startup=> extras_binary_startup
+            b% extras_binary_check_model=> extras_binary_check_model
+            b% extras_binary_finish_step => extras_binary_finish_step
+            b% extras_binary_after_evolve=> extras_binary_after_evolve
+   
+            ! Once you have set the function pointers you want, then uncomment this (or set it in your star_job inlist)
+            ! to disable the printed warning message,
+             b% warn_binary_extra =.false.
+   
+             b% other_sync_spin_to_orbit => my_sync_spin_to_orbit
+             b% other_tsync => my_tsync
+             b% other_mdot_edd => my_mdot_edd
+         end subroutine extras_binary_controls
+   
+         subroutine my_tsync(id, sync_type, Ftid, qratio, m, r_phot, osep, t_sync, ierr)
+            integer, intent(in) :: id
+            character (len=strlen), intent(in) :: sync_type !synchronization timescale
+            real(dp), intent(in) :: Ftid ! efficiency of tidal synchronization. (time scale / Ftid ).
+            real(dp), intent(in) :: qratio !mass_other_star/mass_this_star
+            real(dp), intent(in) :: m
+            real(dp), intent(in) :: r_phot
+            real(dp), intent(in) :: osep ! orbital separation (cm)
+            real(dp), intent(out) :: t_sync
+            integer, intent(out) :: ierr
+            real(dp) :: rGyr_squared , moment_of_inertia
+            real(dp) :: one_div_t_sync_conv, one_div_t_sync_rad, one_div_t_sync ! t_sync_rad, t_sync_conv
+            type (binary_info), pointer :: b
+            type (star_info), pointer :: s
+   
+            ierr = 0
+            call star_ptr(id, s, ierr)
+            if (ierr /= 0) then
+              write(*,*) 'failed in star_ptr'
+               return
+            end if
+   
+            call binary_ptr(s% binary_id, b, ierr)
+            if (ierr /= 0) then
+               write(*,*) 'failed in binary_ptr'
+               return
+            end if
+            moment_of_inertia = dot_product(s% i_rot(:s% nz)% val, s% dm_bar(:s%nz))
+            rGyr_squared = (moment_of_inertia/(m*r_phot*r_phot))
+   
+            ! Implemented the option for both equilibrium and dynamical tides
+            if (sync_type == "Hut_conv") then
+                    !sync_type .eq. "Hut_conv"!Convective envelope + Radiative core
+                    ! eq. (11) of Hut, P. 1981, A&A, 99, 126
+                    t_sync = 3.0d0*k_div_T(b, s,.true.)*(qratio*qratio/rGyr_squared)*pow6(r_phot/osep)
+                    ! invert it.
+                    !write(*,*) 'star id', s% id
+                    if (b% point_mass_i /= 1 .and. b% s1% id == s% id) then
+                      b% s1% xtra(2) = 1d0/t_sync
+                      !write(*,*) 'two timescales ', b% s1% xtra(1), b% s1% xtra(2)
+                    else if (b% point_mass_i /= 2 .and. b% s2% id == s% id) then
+                      b% s2% xtra(2) = 1d0/t_sync
+                      !write(*,*) 'two timescales ', b% s2% xtra(1), b% s2% xtra(2)
+                    else
+                      write(*,*) 'something is not going well with the stars IDs '
+                    end if
+                    t_sync = 1d0/t_sync
+                    !write(*,*) 'Hut_conv ', t_sync
+           else if (sync_type == "Hut_rad") then
+                    !sync_type .eq. "Hut_rad"! Radiative envelope + convective core
+                    ! eq. (11) of Hut, P. 1981, A&A, 99, 126
+                    t_sync = 3.0*k_div_T(b, s,.false.)*(qratio*qratio/rGyr_squared)*pow6(r_phot/osep)
+                    ! invert it.
+                    !write(*,*) 'star id', s% id
+                    if (b% point_mass_i /= 1 .and. b% s1% id == s% id) then
+                      b% s1% xtra(1) = 1d0/t_sync
+                      !write(*,*) 'two timescales ', b% s1% xtra(1), b% s1% xtra(2)
+                    else if (b% point_mass_i /= 2 .and. b% s2% id == s% id) then
+                      b% s2% xtra(1) = 1d0/t_sync
+                      !write(*,*) 'two timescales ', b% s2% xtra(1), b% s2% xtra(2)
+                    else
+                      write(*,*) 'something is not going well with the stars IDs '
+                    end if
+                    t_sync = 1d0/t_sync
+                    !write(*,*) 'Hut_rad ', t_sync
+            else if (sync_type == "structure_dependent") then !  Calculates both timescales from "Hut_rad" and "Hut_conv" and picks the shortest
+                     one_div_t_sync_conv = 3.0d0*k_div_T_posydon(b, s, .true.)*(qratio*qratio/rGyr_squared)*pow6(r_phot/osep)
+                     one_div_t_sync_rad = 3.0d0*k_div_T_posydon(b, s, .false.)*(qratio*qratio/rGyr_squared)*pow6(r_phot/osep)
+                     !write(*,*) 'star id', s% id
+                     if (b% point_mass_i /= 1 .and. b% s1% id == s% id) then
+                       b% s1% xtra(1) = 1d0/one_div_t_sync_rad
+                       b% s1% xtra(2) = 1d0/one_div_t_sync_conv
+                       !write(*,*) 'two timescales ', b% s1% xtra(1), b% s1% xtra(2)
+                     else if (b% point_mass_i /= 2 .and. b% s2% id == s% id) then
+                       b% s2% xtra(1) = 1d0/one_div_t_sync_rad
+                       b% s2% xtra(2) = 1d0/one_div_t_sync_conv
+                       !write(*,*) 'two timescales ', b% s2% xtra(1), b% s2% xtra(2)
+                     else
+                        write(*,*) 'something is not going well with the stars IDs '
+                     end if
+                     !write(*,*) 'two 1/timescales ', one_div_t_sync_conv , one_div_t_sync_rad
+                     !write(*,*) 'two timescales ', b% s1% ixtra1, b% s1% ixtra2
+                     one_div_t_sync = MAX(one_div_t_sync_conv,one_div_t_sync_rad)
+                     !one_div_t_sync = one_div_t_sync_conv1 + one_div_t_sync_conv2 + one_div_t_sync_rad ! if we want to combine them
+                     t_sync = 1d0/one_div_t_sync
+                     !write(*,*) 't_tides in years', t_sync / secyer
+            else if (sync_type == "Orb_period") then ! sync on timescale of orbital period
+                    t_sync = b% period ! synchronize on timescale of orbital period
+            else
+                   ierr = -1
+                   write(*,*) 'unrecognized sync_type', sync_type
+                   return
+           end if
+           t_sync = t_sync / Ftid
+         end subroutine my_tsync
+   
+         subroutine get_tsync(id, sync_type, Ftid, qratio, m, r_phot, osep, t_sync, ierr)
+            integer, intent(in) :: id
+            character (len=strlen), intent(in) :: sync_type ! synchronization timescale
+            real(dp), intent(in) :: Ftid ! efficiency of tidal synchronization. (time scale / Ftid ).
+            real(dp), intent(in) :: qratio ! mass_other_star/mass_this_star
+            real(dp), intent(in) :: m
+            real(dp), intent(in) :: r_phot
+            real(dp), intent(in) :: osep ! orbital separation (cm)
+            real(dp), intent(out) :: t_sync
+            integer, intent(out) :: ierr
+            real(dp) :: rGyr_squared, moment_of_inertia
+            type (binary_info), pointer :: b
+            type (star_info), pointer :: s
+   
+            include 'formats'
+   
+            ierr = 0
+   
+            call star_ptr(id, s, ierr)
+            if (ierr /= 0) then
+               write(*,*) 'failed in star_ptr'
+               return
+            end if
+   
+            call binary_ptr(s% binary_id, b, ierr)
+            if (ierr /= 0) then
+               write(*,*) 'failed in binary_ptr'
+               return
+            end if
+            ! calculate the gyration radius squared
+            moment_of_inertia = dot_product(s% i_rot(:s% nz)% val, s% dm_bar(:s% nz))
+            rGyr_squared = (moment_of_inertia/(m*r_phot*r_phot))
+            if (sync_type == "Hut_conv") then
+               ! eq. (11) of Hut, P. 1981, A&A, 99, 126
+               t_sync = 3.0*k_div_T(b, s, .true.)*(qratio*qratio/rGyr_squared)*pow6(r_phot/osep)
+               ! invert it.
+               t_sync = 1d0/t_sync
+            else if (sync_type == "Hut_rad") then
+               ! eq. (11) of Hut, P. 1981, A&A, 99, 126
+               t_sync = 3.0*k_div_T(b, s,.false.)*(qratio*qratio/rGyr_squared)*pow6(r_phot/osep)
+               ! invert it.
+               t_sync = 1d0/t_sync
+            else if (sync_type == "Orb_period") then ! sync on timescale of orbital period
+               t_sync = b% period ! synchronize on timescale of orbital period
+            else
+               ierr = -1
+               write(*,*) 'unrecognized sync_type', sync_type
+               return
+            end if
+            t_sync = t_sync / Ftid
+         end subroutine get_tsync
+   
+         subroutine my_sync_spin_to_orbit(id, nz, osep, qratio, rl, dt_next, Ftid,sync_type, sync_mode, ierr)
+             use const_def, only: dp, strlen
+             integer, intent(in) :: id
+             integer, intent(in) :: nz
+             real(dp), intent(in) :: osep ! orbital separation (cm)
+             real(dp), intent(in) :: qratio ! mass_other_star/mass_this_star
+             real(dp), intent(in) :: rl ! roche lobe radius (cm)
+             real(dp), intent(in) :: dt_next ! next timestep
+             real(dp), intent(in) :: Ftid ! efficiency of tidal synchronization. (time scale / Ftid ).
+   
+             character (len=strlen), intent(in) :: sync_type ! synchronization timescale
+             character (len=strlen), intent(in) :: sync_mode ! where to put/take angular momentum
+             integer, intent(out) :: ierr
+             type (star_info), pointer :: s
+             type (binary_info), pointer :: b
+   
+             integer :: k
+             real(dp), dimension(nz) :: j_sync, delta_j
+             real(dp) :: t_sync, m, r_phot, omega_orb
+             real(dp) :: a1,a2
+   
+             include 'formats'
+             ierr = 0
+   
+             t_sync = 0
+             call star_ptr(id, s, ierr)
+             if (ierr /= 0) then
+                write(*,*) 'failed in star_ptr'
+                return
+             end if
+   
+             call binary_ptr(s% binary_id, b, ierr)
+             if (ierr /= 0) then
+                write(*,*) 'failed in binary_ptr'
+                return
+             end if
+   
+             if (is_donor(b, s)) then
+                m = b% m(b% d_i)
+                r_phot = b% r(b% d_i)
+             else
+                m = b% m(b% a_i)
+                r_phot = b% r(b% a_i)
+             end if
+   
+             omega_orb = 2d0*pi/b% period
+             do k=1,nz
+                j_sync(k) = omega_orb*s% i_rot(k)% val
+             end do
+   
+             if (.not. b% use_other_tsync) then !Default tidal synchronization timescale calculation
+                call get_tsync(s% id, sync_type, Ftid, qratio, m, r_phot, osep, t_sync, ierr)
+                if (ierr/=0) return
+             else
+                call b% other_tsync(s% id, sync_type, Ftid, qratio, m, r_phot, osep, t_sync, ierr)
+                if (ierr/=0) return
+             end if
+             a1 = f2(b% eccentricity)
+             a2 = pow(1-pow2(b% eccentricity), 1.5d0)*f5(b% eccentricity)
+   
+             ! Option for tides to apply only to the envelope. (Qin et al. 2018 implementation)
+             !if (.not. b% have_radiative_core(id)) then ! convective core
+             !    !write(*,*) 'applying tides only in radiative envelope'
+             !    do k=1,nz
+             !       if (s% mixing_type(k) /= convective_mixing) then
+             !           delta_j(k) = (1d0 - exp(-a2*dt_next/t_sync))*(s% j_rot(k) - a1/a2*j_sync(k))
+             !       else
+             !           delta_j(k) = 0.0
+             !       end if
+             !    end do
+             !else
+             !    !write(*,*) 'applying tides only in convective regions'
+             !    do k=1,nz
+             !       if (s% mixing_type(k) == convective_mixing) then
+             !           delta_j(k) = (1d0 - exp(-a2*dt_next/t_sync))*(s% j_rot(k) - a1/a2*j_sync(k))
+             !       else
+             !           delta_j(k) = 0.0
+             !       end if
+             !    end do
+             !end if
+   
+             ! Tides apply in all layers
+             ! write(*,*) 'applying tides in all layers'
+             do k=1,nz
+                 delta_j(k) = (1d0 - exp(-a2*dt_next/t_sync))*(s% j_rot(k) - a1/a2*j_sync(k))
+             end do
+   
+   
+             if (b% point_mass_i /= 1 .and. b% s1% id == s% id) then
+                b% t_sync_1 = t_sync
+             else
+                b% t_sync_2 = t_sync
+             end if
+   
+             if (.not. b% doing_first_model_of_run) then
+                do k=1,nz
+                   s% extra_jdot(k) = s% extra_jdot(k) - delta_j(k)/dt_next
+                end do
+              end if
+          end subroutine my_sync_spin_to_orbit
+   
+          real(dp) function f2(e)
+             real(dp), intent(in) :: e
+   
+             f2 = 1d0
+   
+             ! Hut 1981, A&A, 99, 126, definition of f2 after eq. 11
+             if (e > 0d0) then
+                 f2 = 1d0 + 15d0/2d0 * pow2(e) + 45d0/8d0 * pow4(e) + 5d0/16d0 * pow6(e)
+             end if
+   
+          end function f2
+   
+          real(dp) function f3(e)
+             real(dp), intent(in) :: e
+   
+             f3 = 1d0
+   
+             ! Hut 1981, A&A, 99, 126, definition of f3 after eq. 11
+             if (e > 0d0) then
+                 f3 = 1d0 + 15d0/4d0*pow2(e) + 15d0/8d0 * pow4(e) + 5d0/64d0 * pow6(e)
+             end if
+   
+          end function f3
+   
+   
+          real(dp) function f4(e)
+             real(dp), intent(in) :: e
+   
+             f4 = 1d0
+   
+             ! Hut 1981, A&A, 99, 126, definition of f4 after eq. 11
+             if (e > 0d0) then
+                 f4 = 1d0 + 3d0/2d0 * pow2(e) + 1d0/8d0 * pow4(e)
+             end if
+   
+          end function f4
+   
+   
+          real(dp) function f5(e)
+             real(dp), intent(in) :: e
+   
+             f5 = 1d0
+   
+             ! Hut 1981, A&A, 99, 126, definition of f5 after eq. 11
+             if (e > 0d0) then
+                 f5 = 1d0 + 3d0*pow2(e) + 3d0/8d0 * pow4(e)
+             end if
+   
+          end function f5
+   
+          real(dp) function mass_conv_core(s)
+              type (star_info), pointer :: s
+              integer :: j, nz, k
+              real(dp) :: dm_limit
+              include 'formats'
+              mass_conv_core = 0.0d0
+              dm_limit = s% conv_core_gap_dq_limit*s% xmstar
+              nz = s% nz
+              do j = 1, s% n_conv_regions
+                 ! ignore possible small gap at center
+                 if (s% cz_bot_mass(j) <= s% m(nz) + dm_limit) then
+                    mass_conv_core = s% cz_top_mass(j)/Msun
+                    ! jump over small gaps
+                    do k = j+1, s% n_conv_regions
+                       if (s% cz_bot_mass(k) - s% cz_top_mass(k-1) >= dm_limit) exit
+                       mass_conv_core = s% cz_top_mass(k)/Msun
+                    end do
+                    exit
+                 end if
+              end do
+           end function mass_conv_core
+   
+   
+         real(dp) function k_div_T(b, s, has_convective_envelope)
+            type(binary_info), pointer :: b
+            type(star_info), pointer :: s
+            logical, intent(in) :: has_convective_envelope
+   
+            integer :: k,i, h1
+            real(dp) osep, qratio, m, r_phot,porb, m_env, r_env, tau_conv, P_tid, f_conv,E2, Xs
+   
+            ! k/T computed as in Hurley, J., Tout, C., Pols, O. 2002, MNRAS, 329, 897
+            ! Kudos to Francesca Valsecchi for help implementing and testing this
+   
+             k_div_T = 0d0
+   
+             osep = b% separation
+             qratio = b% m(b% a_i) / b% m(b% d_i)
+             if (is_donor(b, s)) then
+                m = b% m(b% d_i)
+                r_phot = b% r(b% d_i)
+             else
+                qratio = 1.0d0/qratio
+                m = b% m(b% a_i)
+                r_phot = b% r(b% a_i)
+             end if
+             porb = b% period
+   
+             if (has_convective_envelope) then
+                m_env = 0d0
+                r_env = 0d0
+                do k=1, s% nz
+                   if (s% mixing_type(k) /= convective_mixing .and. &
+                       s% rho(k) > 1d5*s% rho(1)) then
+                      r_env = (r_phot - s% r(k))/Rsun
+                      m_env = (s% m(1) - s% m(k))/Msun
+                      exit
+                   end if
+                end do
+                tau_conv = 0.431d0*pow(m_env*r_env* &
+                   (r_phot/Rsun-r_env/2d0)/3d0/s% L_phot,one_third) * secyer
+                P_tid = 1d0/abs(1d0/porb-s% omega_avg_surf/(2d0*pi))
+                f_conv = min(1.0d0, pow(P_tid/(2d0*tau_conv),b% tidal_reduction))
+   
+                k_div_T = 2d0/21d0*f_conv/tau_conv*m_env/(m/Msun)
+             else ! radiative envelope
+              ! New fitting E2 (Qin et al. 2018)
+                do i = s% nz, 1, -1
+                   if (s% brunt_N2(i) >= 0) exit
+                end do
+                !write(*,*) i
+                h1 = s% net_iso(ih1)
+                Xs = s% xa(h1,1)
+                ! E2 is different for H-rich and He stars (Qin et al. 2018)
+                if (Xs < 0.4d0) then ! HeStar
+                   E2 = exp10(-0.93_dp)*pow(s% r(i)/r_phot,6.7_dp)! HeStars
+                else
+                   E2 = exp10(-0.42_dp)*pow(s% r(i)/r_phot,7.5_dp)! H-rich stars
+                !write(*,*) E2, s% r(i)
+                end if
+                if (IEEE_IS_NAN(E2)) then  !maybe this won't be used.
+                    k_div_T = 1d-20
+                else
+                   k_div_T = sqrt(standard_cgrav*m*r_phot*r_phot/pow5(osep)/(Msun/pow3(Rsun)))
+                   k_div_T = k_div_T*pow(1d0+qratio,5d0/6d0)
+                   k_div_T = k_div_T * E2
+                end if
+             end if
+   
+         end function k_div_T
+   
+         subroutine loop_conv_layers(s,n_conv_regions_posydon, n_zones_of_region, bot_bdy, top_bdy, &
+         cz_bot_mass_posydon, cz_bot_radius_posydon, cz_top_mass_posydon, cz_top_radius_posydon)
+            type (star_info), pointer :: s
+            ! integer, intent(out) :: ierr
+   
+            logical :: in_convective_region
+            integer :: k, j, nz
+            logical, parameter :: dbg = .false.
+            integer, intent(out) :: n_conv_regions_posydon
+            !integer :: max_num_mixing_regions
+            !max_num_mixing_regions = 100
+            !integer, intent(out), dimension (:), allocatable :: n_zones_of_region, bot_bdy, top_bdy
+            !real(dp),intent(out), dimension (:), allocatable :: cz_bot_mass_posydon, cz_bot_radius_posydon
+            !real(dp),intent(out), dimension (:), allocatable :: cz_top_mass_posydon, cz_top_radius_posydon
+            integer :: min_zones_for_convective_tides
+            integer ::  pot_n_zones_of_region, pot_bot_bdy, pot_top_bdy
+            real(dp) :: pot_cz_bot_mass_posydon, pot_cz_bot_radius_posydon
+            integer, intent(out), dimension (max_num_mixing_regions) :: n_zones_of_region, bot_bdy, top_bdy
+            real(dp),intent(out), dimension (max_num_mixing_regions) :: cz_bot_mass_posydon
+            real(dp),intent(out) :: cz_bot_radius_posydon(max_num_mixing_regions)
+            real(dp),intent(out), dimension (max_num_mixing_regions) :: cz_top_mass_posydon, cz_top_radius_posydon
+   
+            include 'formats'
+            !ierr = 0
+            min_zones_for_convective_tides = 10
+            nz = s% nz
+            n_zones_of_region(:)=0
+            bot_bdy(:)=0
+            top_bdy(:)=0
+            cz_bot_mass_posydon(:)=0.0d0
+            cz_bot_radius_posydon(:)=0.0d0
+            cz_top_mass_posydon(:)=0.0d0
+            cz_top_radius_posydon(:)=0.0d0
+            n_conv_regions_posydon = 0
+            pot_cz_bot_mass_posydon = 0.0d0
+            pot_cz_bot_radius_posydon = 0.0d0
+            pot_bot_bdy = 0
+            pot_n_zones_of_region = 0
+   
+            in_convective_region = (s% mixing_type(nz) == convective_mixing)
+            if (in_convective_region) then
+               pot_cz_bot_mass_posydon = s% M_center
+               pot_cz_bot_radius_posydon = 0.0d0
+               pot_bot_bdy = nz
+            end if
+   
+            !write(*,*) 'initial in_convective_region', in_convective_region
+   
+            do k=nz-1, 2, -1
+               if (in_convective_region) then
+                  if (s% mixing_type(k) /= convective_mixing) then ! top of convective region
+                     pot_top_bdy = k
+                     pot_n_zones_of_region = pot_bot_bdy - pot_top_bdy
+                     if (pot_n_zones_of_region >= min_zones_for_convective_tides) then
+                       if (n_conv_regions_posydon < max_num_mixing_regions) then
+                         n_conv_regions_posydon = n_conv_regions_posydon + 1
+                       end if
+                       cz_top_mass_posydon(n_conv_regions_posydon) = &
+                         s% M_center + (s% q(k) - s% cz_bdy_dq(k))*s% xmstar
+                       cz_bot_mass_posydon(n_conv_regions_posydon) = pot_cz_bot_mass_posydon
+                       cz_top_radius_posydon(n_conv_regions_posydon) = s% r(k)/Rsun
+                       cz_bot_radius_posydon(n_conv_regions_posydon) = pot_cz_bot_radius_posydon
+                       top_bdy(n_conv_regions_posydon) = pot_top_bdy
+                       bot_bdy(n_conv_regions_posydon) = pot_bot_bdy
+                       n_zones_of_region(n_conv_regions_posydon) = pot_n_zones_of_region
+                     end if
+                     in_convective_region = .false.
+                  end if
+               else
+                  if (s% mixing_type(k) == convective_mixing) then ! bottom of convective region
+                     pot_cz_bot_mass_posydon = &
+                       s% M_center + (s% q(k) - s% cz_bdy_dq(k))*s% xmstar
+                     pot_cz_bot_radius_posydon = s% r(k)/Rsun
+                     pot_bot_bdy = k
+                     in_convective_region = .true.
+                  end if
+               end if
+            end do
+            if (in_convective_region) then
+               pot_top_bdy = 1
+               pot_n_zones_of_region = pot_bot_bdy - pot_top_bdy
+               if (pot_n_zones_of_region >= min_zones_for_convective_tides) then
+                 if (n_conv_regions_posydon < max_num_mixing_regions) then
+                   n_conv_regions_posydon = n_conv_regions_posydon + 1
+                 end if
+                 cz_top_mass_posydon(n_conv_regions_posydon) = s% mstar
+                 cz_top_radius_posydon(n_conv_regions_posydon) = s% r(1)/Rsun
+                 top_bdy(n_conv_regions_posydon) = 1
+                 cz_bot_mass_posydon(n_conv_regions_posydon) = pot_cz_bot_mass_posydon
+                 cz_bot_radius_posydon(n_conv_regions_posydon) = pot_cz_bot_radius_posydon
+                 bot_bdy(n_conv_regions_posydon) = pot_bot_bdy
+                 n_zones_of_region(n_conv_regions_posydon) = pot_n_zones_of_region
+              end if
+            end if
+   
+             !write(*,*)
+             !write(*,2) 'set_mixing_info n_conv_regions_posydon', n_conv_regions_posydon
+             !do j = 1, n_conv_regions_posydon
+             !   write(*,2) 'conv region', j, cz_bot_mass_posydon(j)/Msun, cz_top_mass_posydon(j)/Msun
+             !   write(*,2) 'conv region', j, cz_bot_radius_posydon(j), cz_top_radius_posydon(j)
+             !end do
+             !write(*,*)
+         end subroutine loop_conv_layers
+   
+         real(dp) function k_div_T_posydon(b, s, conv_layer_calculation)
+            type(binary_info), pointer :: b
+            type(star_info), pointer :: s
+            !logical, intent(in) :: has_convective_envelope
+            logical, intent(in) :: conv_layer_calculation
+   
+            integer :: k,i, h1, top_bound_zone, bot_bound_zone
+            real(dp) :: osep, qratio, m, r_phot,porb, m_env, Dr_env, Renv_middle, tau_conv, P_tid, f_conv,E2, Xs, m_conv_core
+            real(dp) :: k_div_T_posydon_new, conv_mx_top, conv_mx_bot, conv_mx_top_r, conv_mx_bot_r ,omega_conv_region,r_top, r_bottom
+            integer :: n_conv_regions_posydon
+            integer,  dimension (max_num_mixing_regions) :: n_zones_of_region, bot_bdy, top_bdy
+            real(dp), dimension (max_num_mixing_regions) :: cz_bot_mass_posydon
+            real(dp) :: cz_bot_radius_posydon(max_num_mixing_regions)
+            real(dp), dimension (max_num_mixing_regions) :: cz_top_mass_posydon, cz_top_radius_posydon
+
+   
+            ! k/T computed as in Hurley, J., Tout, C., Pols, O. 2002, MNRAS, 329, 897
+            ! Kudos to Francesca Valsecchi for help implementing and testing this
+   
+             k_div_T_posydon = 0d0
+   
+             osep = b% separation
+             qratio = b% m(b% a_i) / b% m(b% d_i)
+             if (is_donor(b, s)) then
+                m = b% m(b% d_i)
+                r_phot = b% r(b% d_i)
+             else
+                qratio = 1.0d0/qratio
+                m = b% m(b% a_i)
+                r_phot = b% r(b% a_i)
+             end if
+             porb = b% period
+   
+             if (conv_layer_calculation) then
+               m_conv_core = mass_conv_core(s)
+               ! In POSYDON the calculation is done for the most important convective layer, found below
+               n_zones_of_region(:)=0
+               bot_bdy(:)=0
+               top_bdy(:)=0
+               cz_bot_mass_posydon(:)=0.0d0
+               cz_bot_radius_posydon(:)=0.0d0
+               cz_top_mass_posydon(:)=0.0d0
+               cz_top_radius_posydon(:)=0.0d0
+               n_conv_regions_posydon = 0
+   
+               call loop_conv_layers(s,n_conv_regions_posydon, n_zones_of_region, bot_bdy, top_bdy, &
+         cz_bot_mass_posydon, cz_bot_radius_posydon, cz_top_mass_posydon, cz_top_radius_posydon)
+   
+               if (n_conv_regions_posydon > 0) then
+                 do k=1, n_conv_regions_posydon ! from inside out
+                   m_env = 0.0d0
+                   Dr_env = 0.0d0
+                   Renv_middle = 0.0d0
+                   if ((cz_bot_mass_posydon(k) / Msun) >=  m_conv_core) then ! if the conv. region is not inside the conv. core
+                       m_env = (cz_top_mass_posydon(k) - cz_bot_mass_posydon(k)) / Msun
+                       Dr_env = cz_top_radius_posydon(k) - cz_bot_radius_posydon(k)  ! depth of the convective layer, length of the eddie
+                       ! Corresponding to the Renv term in eq.31 of Hurley et al. 2002
+                       ! and to (R-Renv) term in eq. 4 of Rasio et al. 1996  (different notation)
+                       Renv_middle = (cz_top_radius_posydon(k) + cz_bot_radius_posydon(k) )*0.5d0  ! middle of the convective layer
+                       ! Corresponding to the (R-0.5d0*Renv) in eq.31 of Hurley et al 2002
+                       ! and to the Renv in eq. 4 of Rasio et al. 1996
+                       ! where it represented the base of the convective layer (different notation)
+                       tau_conv = 0.431_dp*pow(m_env*Dr_env* &
+                          Renv_middle/3d0/s% L_phot,1.0d0/3.0d0) * secyer
+                       P_tid = 1d0/abs(1d0/porb-s% omega(top_bdy(k))/(2d0*pi))
+                       f_conv = min(1.0d0, pow(P_tid/(2d0*tau_conv), b% tidal_reduction))
+                       !write(*,'(g0)') 'porb, p_from_omega, f_conv = ', porb, &
+      !1                / (s% omega(top_bdy(k))/(2d0*pi)), &
+      !1                /(s% omega_avg_surf/(2d0*pi)), f_conv
+                       k_div_T_posydon_new = 2d0/21d0*f_conv/tau_conv*m_env/(m/Msun)
+                       !write(*,'(g0)') 'tau_conv, K/T = ', tau_conv, k_div_T_posydon_new, m_env, (m/Msun)
+                       if (k_div_T_posydon_new >= k_div_T_posydon) then
+                         k_div_T_posydon = k_div_T_posydon_new
+                         !write(*,'(g0)') 'M_env, DR_env, Renv_middle, omega_conv_region in conv region ', k ,' is ', &
+                          ! m_env, Dr_env, Renv_middle, s% omega(top_bdy(k)), 'spanning number of zones = ', &
+                           !top_bdy(k) , bot_bdy(k), &
+                           !n_zones_of_region(k)
+                       end if
+                   end if
+                 end do
+               end if
+             else ! assuming a radiative star
+              ! New fitting E2 (Qin et al. 2018)
+                do i = s% nz, 1, -1
+                   if (s% brunt_N2(i) >= 0d0) exit
+                end do
+                !write(*,*) i
+           if (i == 0) then ! expected in a fully convective star
+              E2 = 1d-99
+           else
+              h1 = s% net_iso(ih1)
+             Xs = s% xa(h1,1)
+              ! E2 is different for H-rich and He stars (Qin et al. 2018)
+              if (Xs < 0.4d0) then ! HeStar
+             E2 = exp10(-0.93_dp)*pow(s% r(i)/r_phot, 6.7_dp)! HeStars
+              else
+             E2 = exp10(-0.42_dp)*pow(s% r(i)/r_phot, 7.5_dp)! H-rich stars
+              !write(*,*) E2, s% r(i)
+              end if
+           end if
+   
+                if ( IEEE_IS_NAN(E2) ) then  !maybe this won't be used.
+                    k_div_T_posydon = 1d-99
+                else
+                   k_div_T_posydon = sqrt(standard_cgrav*m*r_phot*r_phot/pow5(osep)/(Msun/pow3(Rsun)))
+                   k_div_T_posydon = k_div_T_posydon*pow(1d0+qratio,5d0/6d0)
+                   k_div_T_posydon = k_div_T_posydon * E2
+                end if
+             end if
+   
+         end function k_div_T_posydon
+   
+   
+   
+   
+         real(dp) function acc_radius(b, m_acc) !Calculates Sch. radius of compact object (or surface radius in case of NS) in cm
+             type(binary_info), pointer :: b
+             real(dp) :: m_acc, a
+             real(dp) :: r_isco, Z1, Z2, eq_initial_bh_mass
+   
+             if (m_acc/Msun <= 2.50d0) then ! NS
+               !Radius refernces for NS:
+               ! 1) Miller, M. C., Lamb, F. K., Dittmann, A. J., et al. 2019, ApJL, 887, L2
+               ! 2) Riley, T. E., Watts, A. L., Bogdanov, S., et al., 2019, ApJL, 887, L21
+               ! 3) Landry, P., Essick, R., & Chatziioannou, K. 2020
+               ! 4) E.R. Most, L.R. Weih, L. Rezzolla and J. Schaffner-Bielich, 2018, Phys. Rev. Lett. 120, 261103
+               ! 5) Abbott, B. P., Abbott, R., Abbott, T. D., et al. 2020, ApJL, 892, L3
+               acc_radius = 12.5E5_dp !* 10 ** 5 !in cm
+             else ! Event horizon for Kerr-BH
+               ! this part is only relevant for BH accretors
+               if (b% initial_bh_spin < 0d0) then
+                  b% initial_bh_spin = 0d0
+                  write(*,*) "initial_bh_spin is smaller than zero. It has been set to zero."
+               else if (b% initial_bh_spin > 1d0) then
+                  b% initial_bh_spin = 1d0
+                  write(*,*) "initial_bh_spin is larger than one. It has been set to one."
+               end if
+               ! compute isco radius from eq. 2.21 of Bardeen et al. (1972), ApJ, 178, 347
+               Z1 = 1d0 + pow(1d0 - pow2(b% initial_bh_spin),one_third) &
+                  * (pow(1d0 + b% initial_bh_spin,one_third) + pow(1d0 - b% initial_bh_spin,one_third))
+               Z2 = sqrt(3d0*pow2(b% initial_bh_spin) + pow2(Z1))
+               r_isco = 3d0 + Z2 - sqrt((3d0 - Z1)*(3d0 + Z1 + 2d0*Z2))
+               ! compute equivalent mass at zero spin from eq. (3+1/2) (ie. the equation between (3) and (4))
+               ! of Bardeen (1970), Nature, 226, 65, taking values with subscript zero to correspond to
+               ! zero spin (r_isco = sqrt(6)).
+   
+           if (initial_mass(2) > 2.5_dp) then ! If it was already a BH then take the initial mass m2
+         eq_initial_bh_mass = b% eq_initial_bh_mass
+           else if (initial_mass(2) <= 2.5_dp) then! If it was initially a NS then take 2.5Msun as eq_initial_mass
+             eq_initial_bh_mass = 2.5_dp * Msun * sqrt(r_isco/6d0)
+           end if
+   
+               a = sqrt(two_thirds) &
+                 *(eq_initial_bh_mass/min(b% m(b% point_mass_i),sqrt(6d0)* eq_initial_bh_mass)) &
+                 *(4._dp - sqrt(18._dp*pow2(eq_initial_bh_mass/ &
+                 min(b% m(b% point_mass_i),sqrt(6d0)* eq_initial_bh_mass)) - 2._dp))
+               !Podsiadlowski et al. (2003) assuming a initially non-rotating BH
+               acc_radius = (1.0_dp + sqrt(1.0_dp - a*a)) * b% s_donor% cgrav(1) * m_acc/pow2(clight)
+             end if
+         end function acc_radius
+   
+         !! Eddington accreton limits for NS and BH
+         subroutine my_mdot_edd(binary_id, mdot_edd, mdot_edd_eta, ierr)
+            use const_def, only: dp
+            integer, intent(in) :: binary_id
+            real(dp), intent(out) :: mdot_edd,mdot_edd_eta
+            integer, intent(out) :: ierr
+            real(dp) :: r_isco, Z1, Z2, eq_initial_bh_mass
+            type (binary_info), pointer :: b
+            ierr = 0
+            call binary_ptr(binary_id, b, ierr)
+            if (ierr /= 0) then
+               write(*,*) 'failed in binary_ptr'
+               return
+            end if
+            if (b% m(2)/Msun > 2.50_dp) then ! M2 > 2.5 Msol for BHs
+                ! this part is only relevant for BH accretors
+                if (b% initial_bh_spin < 0d0) then
+                   b% initial_bh_spin = 0d0
+                   write(*,*) "initial_bh_spin is smaller than zero. It has been set to zero."
+                else if (b% initial_bh_spin > 1d0) then
+                   b% initial_bh_spin = 1d0
+                   write(*,*) "initial_bh_spin is larger than one. It has been set to one."
+                end if
+                ! compute isco radius from eq. 2.21 of Bardeen et al. (1972), ApJ, 178, 347
+                Z1 = 1d0 + pow(1d0 - pow2(b% initial_bh_spin),one_third) &
+                   * (pow(1d0 + b% initial_bh_spin,one_third) + pow(1d0 - b% initial_bh_spin,one_third))
+                Z2 = sqrt(3d0*pow2(b% initial_bh_spin) + pow2(Z1))
+                r_isco = 3d0 + Z2 - sqrt((3d0 - Z1)*(3d0 + Z1 + 2d0*Z2))
+                ! compute equivalent mass at zero spin from eq. (3+1/2) (ie. the equation between (3) and (4))
+                ! of Bardeen (1970), Nature, 226, 65, taking values with subscript zero to correspond to
+                ! zero spin (r_isco = sqrt(6)).
+   
+                if (initial_mass(2) > 2.5_dp) then ! If it was already a BH then take the initial mass m2
+                   eq_initial_bh_mass = b% eq_initial_bh_mass
+                else if (initial_mass(2) <= 2.5_dp) then! If it was initially a NS then take 2.5 as eq_initial_mass
+                  eq_initial_bh_mass = 2.5_dp * Msun * sqrt(r_isco/6d0)
+                end if
+   
+                !! mdot_edd_eta for BH following Podsiadlowski, Rappaport & Han (2003), MNRAS, 341, 385
+                mdot_edd_eta = 1d0 - sqrt(1d0 - &
+                      pow2(min(b% m(b% a_i),sqrt(6d0)*eq_initial_bh_mass)/(3d0*eq_initial_bh_mass)))
+            else ! NS
+                !! mdot_edd_eta for NS accretors
+                mdot_edd_eta = b% s_donor% cgrav(1) * b% m(2) / (pow2(clight) * acc_radius(b, b% m(2)))
+            end if
+            mdot_edd = 4d0*pi*b% s_donor% cgrav(1)*b% m(b% a_i) &
+                     /(clight*0.2d0*(1d0+b% s_donor% surface_h1)*mdot_edd_eta)
+             !b% s1% x_ctrl(1) used to adjust the Eddington limit in inlist1
+             mdot_edd = mdot_edd * b% s1% x_ctrl(1)
+         end subroutine my_mdot_edd
+   
+         integer function how_many_extra_binary_history_columns(binary_id)
+            use binary_def, only: binary_info
+            integer, intent(in) :: binary_id
+            how_many_extra_binary_history_columns = 6
+         end function how_many_extra_binary_history_columns
+   
+         subroutine data_for_extra_binary_history_columns(binary_id, n, names, vals, ierr)
+            use const_def, only: dp
+            type (binary_info), pointer :: b
+            integer, intent(in) :: binary_id
+            integer, intent(in) :: n
+            character (len=maxlen_binary_history_column_name) :: names(n)
+            real(dp) :: vals(n)
+            integer, intent(out) :: ierr
+            integer:: i_don, i_acc
+            real(dp) :: beta, trap_rad, mdot_edd, mdot_edd_eta, accretor_radius
+   
+             ierr = 0
+   
+            call binary_ptr(binary_id, b, ierr)
+            if (ierr /= 0) then ! failure in  binary_ptr
+               return
+            end if
+   
+            call my_mdot_edd(binary_id,mdot_edd,mdot_edd_eta,ierr)
+   
+            if (b% point_mass_i == 0) then ! if there is no compact object then trappping radius is 0
+              trap_rad = 0.0_dp
+              accretor_radius = 0.0_dp
+            else ! Begelman 1997 and King & Begelman 1999 eq. 1: accretor is star 2
+              trap_rad = 0.5_dp*abs(b% mtransfer_rate) * acc_radius(b, b% m(2)) / mdot_edd
+              accretor_radius = acc_radius(b, b% m(2))
+            end if
+   
+            names(1) = 'trap_radius'
+            vals(1) = trap_rad/Rsun ! in Rsun units
+            names(2) = 'acc_radius'
+            vals(2) = accretor_radius ! in cm units
+   
+           names(3) = 't_sync_rad_1'
+           names(4) = 't_sync_conv_1'
+           names(5) = 't_sync_rad_2'
+           names(6) = 't_sync_conv_2'
+           if (b% point_mass_i /= 1) then
+             vals(3) = b% s1% xtra(1)
+             vals(4) = b% s1% xtra(2)
+           else
+             vals(3) = -1.0d0
+             vals(4) = -1.0d0
+           end if
+           if (b% point_mass_i /= 2) then
+              vals(5) = b% s2% xtra(1)
+              vals(6) = b% s2% xtra(2)
+           else
+             vals(5) = -1.0d0
+             vals(6) = -1.0d0
+           end if
+            !write(*,*) "synchr timescales: ", b% s1% xtra(1), b% s1% xtra(2), b% s2% xtra(1), b% s2% xtra(2)
+         end subroutine data_for_extra_binary_history_columns
+   
+   
+         integer function extras_binary_startup(binary_id,restart,ierr)
+            type (binary_info), pointer :: b
+            integer, intent(in) :: binary_id
+            integer, intent(out) :: ierr
+            logical, intent(in) :: restart
+            call binary_ptr(binary_id, b, ierr)
+            if (ierr /= 0) then ! failure in  binary_ptr
+               return
+            end if
+   
+            if (.not. restart) then
+               ! extras are used to store the two tidal sychronization timescales (rad/conv) for each star.
+               ! -1 if they are point masses
+               if (b% point_mass_i /= 1) then
+                 b% s1% xtra(1) = -1.0d0 ! t_sync_rad_1
+                 b% s1% xtra(2) = -1.0d0 ! t_sync_conv_1
+               end if
+               if (b% point_mass_i /= 2) then
+                 b% s2% xtra(1) = -1.0d0 ! t_sync_rad_2
+                 b% s2% xtra(2) = -1.0d0 ! t_sync_conv_2
+               end if
+            end if
+            extras_binary_startup = keep_going
+         end function  extras_binary_startup
+   
+         !Return either rety,backup,keep_going or terminate
+         integer function extras_binary_check_model(binary_id)
+            type (binary_info), pointer :: b
+            integer, intent(in) :: binary_id
+            integer:: i_don, i_acc
+             real(dp) :: r_l2, d_l2
+            real(dp) :: q
+            integer :: ierr
+            call binary_ptr(binary_id, b, ierr)
+            if (ierr /= 0) then ! failure in  binary_ptr
+               return
+            end if
+            extras_binary_check_model = keep_going
+   
+   
+          if (b% point_mass_i /= 1) then !Check for L2 overflow for primary when not in MS
+             if (b% s1% center_h1 < 1.0d-6) then ! Misra et al. 2020 L2 overflow check starts only after TAMS of one of the two stars. Before we use Marchant et al. 2016 L2 overflow check implemented already in MESA
+                i_don = 1
+                i_acc = 2
+                  if (b% m(i_don) .gt. b% m(i_acc)) then !mdon>macc, q<1
+                     q = b% m(i_acc) / b% m(i_don)
+                     r_l2 = b% rl(i_don) * (0.784_dp * pow(q,1.05_dp) * exp(-0.188_dp*q) + 1.004_dp)
+                     d_l2 = b% rl(i_don) * (3.334_dp * pow(q, 0.514_dp) * exp(-0.052_dp*q) + 1.308_dp)
+                     !Condition to stop when star overflows L2
+                     if (b% r(i_don) .ge. (r_l2)) then
+                        extras_binary_check_model = terminate
+                        write(*,'(g0)') 'termination code: overflow from L2 (R_L2) surface for q(=Macc/Mdon)<1, donor is star 1'
+                        return
+                     end if
+                     if (b% r(i_don) .ge. (d_l2)) then
+                        extras_binary_check_model = terminate
+                        write(*,'(g0)') 'termination code: overflow from L2 (D_L2) distance for q(=Macc/Mdon)<1, donor is star 1'
+                        return
+                     end if
+   
+                  else             !mdonor<maccretor  Condition to stop when mass loss from L2 (previously it was L3) q>1
+                     q = b% m(i_acc) / b% m(i_don)
+                     r_l2 = b% rl(i_don) * (0.29066811_dp * pow(q, 0.82788069_dp) * exp(-0.01572339_dp*q) + 1.36176161_dp)
+                     d_l2 = b% rl(i_don) * (-0.04029713_dp * pow(q, 0.862143_dp) * exp(-0.04049814_dp*q) + 1.88325644_dp)
+                     if (b% r(i_don) .ge. (r_l2)) then
+                        extras_binary_check_model = terminate
+                        write(*,'(g0)') 'termination code: overflow from L2 (R_L2) surface for q(=Macc/Mdon)>1, donor is star 1'
+                        return
+                     end if
+                     if (b% r(i_don) .ge. (d_l2)) then
+                        extras_binary_check_model = terminate
+                        write(*,'(g0)') 'termination code: overflow from L2 (D_L2) distance for q(=Macc/Mdon)>1, donor is star 1'
+                        return
+                     end if
+                  end if
+             end if
+          end if
+   
+          if (b% point_mass_i /= 2) then  !Check for L2 overflow for primary when not in MS
+             if (b% s2% center_h1 < 1.0d-6) then ! Misra et al. 2020 L2 overflow check starts only after TAMS of one of the two stars. Before we use Marchant et al. 2016 L2 overflow check implemented already in MESA
+                i_don = 2
+                i_acc = 1
+                  if (b% m(i_don) .gt. b% m(i_acc)) then !mdon>macc, q<1
+                     q = b% m(i_acc) / b% m(i_don)
+                     r_l2 = b% rl(i_don) * (0.784_dp * pow(q, 1.05_dp) * exp(-0.188_dp * q) + 1.004_dp)
+                     d_l2 = b% rl(i_don) * (3.334_dp * pow(q,  0.514_dp) * exp(-0.052_dp * q) + 1.308_dp)
+                     !Condition to stop when star overflows L2
+                     if (b% r(i_don) .ge. (r_l2)) then
+                        extras_binary_check_model = terminate
+                        write(*,'(g0)') 'termination code: overflow from L2 (R_L2) surface for q(=Macc/Mdon)<1, donor is star 2'
+                        return
+                     end if
+                     if (b% r(i_don) .ge. (d_l2)) then
+                        extras_binary_check_model = terminate
+                        write(*,'(g0)') 'termination code: overflow from L2 (D_L2) distance for q(=Macc/Mdon)<1, donor is star 2'
+                        return
+                     end if
+   
+                  else             !mdonor<maccretor  Condition to stop when mass loss from L2 (previously it was L3) q>1
+                     q = b% m(i_acc) / b% m(i_don)
+                     r_l2 = b% rl(i_don) * (0.29066811_dp * pow(q, 0.82788069_dp) * exp(-0.01572339_dp*q) + 1.36176161_dp)
+                     d_l2 = b% rl(i_don) * (-0.04029713_dp * pow(q, 0.862143_dp) * exp(-0.04049814_dp*q) + 1.88325644_dp)
+                     if (b% r(i_don) .ge. (r_l2)) then
+                        extras_binary_check_model = terminate
+                        write(*,'(g0)') 'termination code: overflow from L2 (R_L2) surface for q(=Macc/Mdon)>1, donor is star 2'
+                        return
+                     end if
+                     if (b% r(i_don) .ge. (d_l2)) then
+                        extras_binary_check_model = terminate
+                        write(*,'(g0)') 'termination code: overflow from L2 (D_L2) distance for q(=Macc/Mdon)>1, donor is star 2'
+                        return
+                     end if
+                  end if
+             end if
+          end if
+   
+          if (b% point_mass_i/=0 .and. ((b% rl_relative_gap(1) .ge. 0.d0) &
+            .or. (abs(b% mtransfer_rate/(Msun/secyer)) .ge. 1.0d-10))) then
+            if (b% point_mass_i/=1) then
+              i_don = 1
+            else
+              i_don = 2
+            end if
+             ! Binary evolution
+             b% do_jdot_mb = .true.
+             b% do_jdot_gr = .true.
+             b% do_jdot_ml = .true.
+             b% do_jdot_ls = .true.
+             b% do_jdot_missing_wind = .true.
+             b% do_j_accretion = .true.
+          end if
+   
+         end function extras_binary_check_model
+   
+         ! returns either keep_going or terminate.
+         ! note: cannot request retry or backup; extras_check_model can do that.
+         integer function extras_binary_finish_step(binary_id)
+            type (binary_info), pointer :: b
+            integer, intent(in) :: binary_id
+            integer :: ierr, star_id, i
+            real(dp) :: q, mdot_limit_low, mdot_limit_high, &
+               center_h1, center_h1_old, center_he4, center_he4_old, &
+               rl23,rl2_1,trap_rad, mdot_edd, mdot_edd_eta
+            logical :: is_ne_biggest
+   
+            extras_binary_finish_step = keep_going
+   
+            call binary_ptr(binary_id, b, ierr)
+            if (ierr /= 0) then ! failure in  binary_ptr
+               return
+            end if
+   
+   
+            if (b% point_mass_i == 0) then
+               ! Check for simultaneous RLOF from both stars after TAMS of one star
+               if (b% s2% center_h1 < 1.0d-6 .or. b% s1% center_h1 < 1.0d-6) then
+                   if (b% rl_relative_gap(1) > 0.0_dp .and. b% rl_relative_gap(2) > 0.0_dp) then
+                     extras_binary_finish_step = terminate
+                     write(*,'(g0)') "termination code: Both stars fill their Roche Lobe and at least one of them is off MS"
+                   end if
+               end if
+            end if
+   
+   
+            !remove gradL_composition term after MS, it can cause the convective helium core to recede
+            if (b% point_mass_i /= 1 .and. b% s1% center_h1 < 1.0d-6) then
+               b% s1% num_cells_for_smooth_gradL_composition_term = 0
+            end if
+            if (b% point_mass_i /= 2 .and. b% s2% center_h1 < 1.0d-6) then
+               b% s2% num_cells_for_smooth_gradL_composition_term = 0
+            end if
+   
+            !check if mass transfer rate reached maximun, assume unstable regime if it happens
+             if (abs(b% mtransfer_rate/(Msun/secyer)) >= 1d-1) then            !stop when larger than 0.1 Msun/yr
+               extras_binary_finish_step = terminate
+               write(*,'(g0)') "termination code: Reached maximum mass transfer rate: 1d-1"
+            end if
+   
+            ! check trapping radius only for runs with a compact object
+            if (b% point_mass_i == 2) then
+              call my_mdot_edd(binary_id,mdot_edd,mdot_edd_eta, ierr)
+   
+              ! Begelman 1997 and King & Begelman 1999 eq. 1: accretor is star 2
+              trap_rad = 0.5_dp*abs(b% mtransfer_rate) * acc_radius(b, b% m(2)) / mdot_edd
+   
+              !check if mass transfer rate reached maximun, assume unstable regime if it happens
+               if (trap_rad >= b% rl(2)) then                                     !stop when trapping radius larger than rl(2)
+               !if (abs(b% mtransfer_rate/(Msun/secyer)) >= 1d-1) then            !stop when larger than 0.1 Msun/yr
+                 extras_binary_finish_step = terminate
+                 write(*,'(g0)') "termination code: Reached maximum mass transfer rate: Exceeded photon trapping radius"
+               end if
+             end if
+   
+            ! check for termination due to carbon depletion
+            if (b% point_mass_i /= 1) then
+               if (b% s1% center_c12 < 1.0d-2 .and. b% s1% center_he4 < 1.0d-6) then
+                     write(*,'(g0)') "termination code: Primary has depleted central carbon"
+                     extras_binary_finish_step = terminate
+                     return
+               !else
+               !   ! check if neon is by far greatest source of energy
+               !   is_ne_biggest = .true.
+               !   do i=1, num_categories
+               !      if(i /= i_burn_ne .and. b% s1% L_by_category(i_burn_ne) < 10*b% s1% L_by_category(i)) then
+               !         is_ne_biggest = .false.
+               !         exit
+               !      end if
+               !   end do
+               !   if (is_ne_biggest .and. b% s1% max_eps_z_m/b% s1% xmstar > 0.01) then
+               !         write(*,'(g0)') "offcenter neon ignition for primary at q=",  b% s1% max_eps_z_m/b% s1% xmstar, &
+               !            b% s1% max_eps_z_m
+               !         extras_binary_finish_step = terminate
+               !         write(*,'(g0)') "termination code: offcenter neon ignition for primary"
+               !   end if
+               end if
+            end if
+   
+            ! check for termination due to carbon depletion
+            if (b% point_mass_i /= 2) then
+               if (b% s2% center_c12 < 1.0d-2 .and. b% s2% center_he4 < 1.0d-6) then
+                     write(*,'(g0)') "termination code: Secondary has depleted central carbon"
+                     extras_binary_finish_step = terminate
+                     return
+               !else
+               !   ! check if neon is by far greatest source of energy
+               !   is_ne_biggest = .true.
+               !   do i=1, num_categories
+               !      if(i /= i_burn_ne .and. b% s2% L_by_category(i_burn_ne) < 10._dp*b% s2% L_by_category(i)) then
+               !         is_ne_biggest = .false.
+               !         exit
+               !      end if
+               !   end do
+               !   if (is_ne_biggest .and. b% s2% max_eps_z_m/b% s2% xmstar > 0.01_dp) then
+               !         write(*,'(g0)') "offcenter neon ignition for secondary at q=",  b% s2% max_eps_z_m/b% s2% xmstar, &
+               !            b% s2% max_eps_z_m
+               !         extras_binary_finish_step = terminate
+               !         write(*,'(g0)') "termination code: offcenter neon ignition for secondary"
+               !   end if
+               end if
+            end if
+   
+            ! check for L2 overflow after ZAMS, but before TAMS as in Marchant et al. 2016
+            if(.not. b% ignore_rlof_flag .and. extras_binary_finish_step /= terminate .and. (b% point_mass_i == 0)) then ! only when we evolve both stars in MS
+               if (b% s1% center_h1 > 1d-6 .and. b% s2% center_h1 > 1d-6) then
+                  if (b% m(1) > b% m(2)) then
+                    q = b% m(2) / b% m(1)
+                    star_id = 2
+                  else
+                    q = b% m(1) / b% m(2)
+                    star_id = 1
+                  end if
+                  if (b% rl_relative_gap(star_id) > 0.29858997d0*atan(1.83530121d0*pow(q,0.39661426d0))) then
+                    write(*,'(g0)') "termination code: Terminate due to L2 overflow during case A"
+                    extras_binary_finish_step = terminate
+                  end if
+               end if
+            end if
+   
+            if (extras_binary_finish_step == terminate) then
+               !write(*,*) "saving final profilesA"
+               !call star_write_profile_info(b% s1% id, "LOGS1/prof_9FINAL.data", b% s1% id, ierr)
+               !if (ierr /= 0) return ! failure in profile
+               !call star_write_profile_info(b% s2% id, "LOGS2/prof_9FINAL.data", b% s2% id, ierr)
+               !if (ierr /= 0) return ! failure in profile
+            else
+               if (b% point_mass_i /= 1) then
+                   if (b% s1% center_h1 < 1d-6 .and. b% mdot_scheme .ne. "Kolb") then ! Changing from 'contact' scheme to Kolb if one star reaches TAMS
+                      b% mdot_scheme = "Kolb"
+                      write(*,*) "Primary reached TAMS, changing mdot_scheme to ", b% mdot_scheme, &
+                                " and changing L2 overflow check according to Misra et al. 2020"
+                      b% terminate_if_L2_overflow = .false.
+                   end if
+               end if
+               if (b% point_mass_i /= 2) then
+                   if (b% s2% center_h1 < 1d-6 .and. b% mdot_scheme .ne. "Kolb") then
+                      b% mdot_scheme = "Kolb"
+                      write(*,*) "Secondary reached TAMS, changing mdot_scheme to", b% mdot_scheme, &
+                                " and changing L2 overflow check according to Misra et al. 2020"
+                      b% terminate_if_L2_overflow = .false.
+                   end if
+               end if
+              !write(*,*) "still using: ", b% mdot_scheme
+   
+               !if (b% model_number == 1 ) then ! Saving initial_profiles
+               !   write(*,*) "saving initial profiles"
+               !   if (b% point_mass_i /= 1) then
+               !        call star_write_profile_info(b% s1% id, "LOGS1/initial_profile.data", b% s1% id, ierr)
+               !   end if
+               !   if (ierr /= 0) return ! failure in profile
+               !   if (b% point_mass_i /= 2) then
+               !        call star_write_profile_info(b% s2% id, "LOGS2/initial_profile.data", b% s2% id, ierr)
+               !   end if
+               !   if (ierr /= 0) return ! failure in profile
+               !end if
+               if (b% model_number == 1 ) then ! Saving initial_models
+                  write(*,*) "saving initial models"
+                  if (b% point_mass_i /= 1) then
+                       call star_write_model(b% s1% id, "initial_star1.mod",  ierr)
+                  end if
+                  if (ierr /= 0) return ! failure
+                  if (b% point_mass_i /= 2) then
+                       call star_write_model(b% s2% id, "initial_star2.mod",  ierr)
+                  end if
+                  if (ierr /= 0) return ! failure
+               end if
+            end if
+   
+         end function extras_binary_finish_step
+   
+         real(dp) function eval_rlobe(m1, m2, a) result(rlobe)
+            real(dp), intent(in) :: m1, m2, a
+            real(dp) :: q
+            q = pow(m1/m2,one_third)
+         ! Roche lobe size for star of mass m1 with a
+         ! companion of mass m2 at separation a, according to
+         ! the approximation of Eggleton 1983, apj 268:368-369
+            rlobe = a*0.49d0*q*q/(0.6d0*q*q + log1p(q))
+         end function eval_rlobe
+   
+         subroutine extras_binary_after_evolve(binary_id, ierr)
+            use run_star_support
+            type (binary_info), pointer :: b
+            integer, intent(in) :: binary_id
+            integer, intent(out) :: ierr
+            type(star_Info), pointer :: s
+            integer :: iounit
+            call binary_ptr(binary_id, b, ierr)
+            if (ierr /= 0) return
+             !if (b% point_mass_i /= 1) then
+                    call star_write_profile_info(b% s1% id, "LOGS1/final_profile.data", ierr)
+             !end if
+               if (ierr /= 0) return ! failure in profile
+   
+               if (b% point_mass_i /= 2) then
+                    call star_write_profile_info(b% s2% id, "LOGS2/final_profile.data", ierr)
+               end if
+               if (ierr /= 0) return ! failure in profile
+   
+         end subroutine extras_binary_after_evolve
+   
+         end module run_binary_extras

--- a/step1_HMS-HMS/src/run_star_extras.f90
+++ b/step1_HMS-HMS/src/run_star_extras.f90
@@ -1,0 +1,2038 @@
+!     ***********************************************************************
+!
+!     Copyright (C) 2010  Bill Paxton
+!
+!     this file is part of mesa.
+!
+!     mesa is free software; you can redistribute it and/or modify
+!     it under the terms of the gnu general library public license as published
+!     by the free software foundation; either version 2 of the license, or
+!     (at your option) any later version.
+!
+!     mesa is distributed in the hope that it will be useful,
+!     but without any warranty; without even the implied warranty of
+!     merchantability or fitness for a particular purpose.  see the
+!     gnu library general public license for more details.
+!
+!     you should have received a copy of the gnu library general public license
+!     along with this software; if not, write to the free software
+!     foundation, inc., 59 temple place, suite 330, boston, ma 02111-1307 usa
+!
+!     ***********************************************************************
+module run_star_extras
+
+      use star_lib
+      use star_def
+      use const_def
+      use math_lib !use crlibm_lib
+      use chem_def
+      use ionization_def
+      use num_lib, only: find0
+    
+      implicit none
+    
+      real(dp) :: original_diffusion_dt_limit
+      logical :: rot_set_check = .false.
+      logical :: TP_AGB_check = .false.
+      logical :: late_AGB_check = .false.
+      logical :: post_AGB_check = .false.
+      logical :: pre_WD_check = .false.
+    
+      ! addition for the check_TP subroutine
+      logical :: have_done_TP = .false.
+      integer :: TP_state = 0
+      integer :: TP_M_H_on = 0
+      integer :: TP_M_H_min = 0
+      integer :: TP_count = 0
+    
+    contains
+    
+      subroutine extras_controls(id, ierr)
+        integer, intent(in) :: id
+        integer, intent(out) :: ierr
+        type (star_info), pointer :: s
+        ierr = 0
+        call star_ptr(id, s, ierr)
+        if (ierr /= 0) return
+    
+        !s% other_mlt => my_other_mlt
+        s% other_am_mixing => TSF
+        s% other_wind => other_set_mdot
+    
+        s% extras_startup => extras_startup
+        s% extras_check_model => extras_check_model
+        s% extras_finish_step => extras_finish_step
+        s% extras_after_evolve => extras_after_evolve
+        s% how_many_extra_history_columns => how_many_extra_history_columns
+        s% data_for_extra_history_columns => data_for_extra_history_columns
+        s% how_many_extra_history_header_items => how_many_extra_history_header_items
+        s% data_for_extra_history_header_items => data_for_extra_history_header_items
+        !s% how_many_extra_profile_header_items => how_many_extra_profile_header_items
+        ! s% data_for_extra_profile_header_items => data_for_extra_profile_header_items
+        s% job% warn_run_star_extras =.false.
+    
+    
+        original_diffusion_dt_limit = s% diffusion_dt_limit
+    
+      end subroutine extras_controls
+    
+    
+      subroutine extras_startup(id, restart, ierr)
+        integer, intent(in) :: id
+        logical, intent(in) :: restart
+        integer, intent(out) :: ierr
+        type (star_info), pointer :: s
+        integer :: j, cid
+        real(dp) :: frac, vct30, vct100
+        character(len=256) :: photosphere_summary, tau100_summary
+        ierr = 0
+        call star_ptr(id, s, ierr)
+        if (ierr /= 0) return
+        !extras_startup = 0
+        if (.not. restart) then
+           call alloc_extra_info(s)
+        else
+           call unpack_extra_info(s)
+        end if
+    
+        if (.not. s% job% extras_lpar(1)) rot_set_check = .true.
+    
+        if(s% initial_mass < 8.0d0 .and. s% initial_mass >= 0.6d0)then
+           TP_AGB_check=.true.
+        endif
+    
+    
+        if (s% star_mass <= 8.0d0) s% cool_wind_RGB_scheme ='Reimers'
+    
+        if(s% x_logical_ctrl(1)) then
+              ! For single stars we allow to go beyong Hubble time,
+              ! to reach TAMS of low mass stars
+              s% max_age = -1
+        endif
+    
+      !prototype version for increasing overshoot above 4 Msun up to the Brott et
+      !al. 2011 value at 8 Msun
+        s% overshoot_f(:)  = f_ov_fcn_of_mass(s% initial_mass)
+    
+        s% overshoot_f0(:) = 8.0d-3
+    
+      end subroutine extras_startup
+    
+      function f_ov_fcn_of_mass(m) result(f_ov)
+        real(dp), intent(in) :: m
+        real(dp) :: f_ov, frac
+        real(dp), parameter :: f1 = 1.6d-2, f2=4.15d-2
+        if(m < 4.0d0) then
+           frac = 0.0d0
+        elseif(m > 8.0d0) then
+           frac = 1.0d0
+        else
+           frac = 0.5d0 * (1.0d0 - cospi(0.25d0*(m-4.0d0)))
+        endif
+        f_ov = f1 + (f2-f1)*frac
+      end function f_ov_fcn_of_mass
+    
+      integer function extras_check_model(id)
+        integer, intent(in) :: id
+        integer :: ierr
+        type (star_info), pointer :: s
+        ierr = 0
+        call star_ptr(id, s, ierr)
+        if (ierr /= 0) return
+        extras_check_model = keep_going
+      end function extras_check_model
+    
+     ! subroutine how_many_extra_history_header_items(id,  num_cols)
+     !     integer, intent(in) :: id
+     !     integer, intent(out) :: num_cols
+     !     num_cols=3
+     ! end subroutine how_many_extra_history_header_items
+    
+    integer function how_many_extra_history_header_items(id)
+       integer, intent(in) :: id
+       integer :: ierr
+       type (star_info), pointer :: s
+       ierr = 0
+       call star_ptr(id, s, ierr)
+       if (ierr /= 0) return
+       how_many_extra_history_header_items = 3
+      end function how_many_extra_history_header_items
+    
+     ! subroutine data_for_extra_history_header_items( &
+     !                 id, id_extra, num_extra_header_items, &
+     !                 extra_header_item_names, extra_header_item_vals, ierr)
+     !     !use chem_def, only: chem_isos
+     !     integer, intent(in) :: id, id_extra, num_extra_header_items
+     !     character (len=*), pointer :: extra_header_item_names(:)
+     !     real(dp), pointer :: extra_header_item_vals(:)
+     !     type(star_info), pointer :: s
+     !     integer, intent(out) :: ierr
+     !     integer :: i
+     !     real(dp) :: Initial_X, Initial_Y, Initial_Z, initial_m
+     !     ierr = 0
+     !     call star_ptr(id,s,ierr)
+     !     if(ierr/=0) return
+     !     !here is an example for adding an extra history header item
+     !     !set num_cols=1 in how_many_extra_history_header_items and then unccomment these lines
+     !     initial_X = 0._dp
+     !     initial_Y = 0._dp
+     !     initial_Z = 0._dp
+     !     initial_m = 0._dp
+     !     do i=1,s% species
+     !        !write(*,*) chem_isos% name(s% chem_id(i)), s% xa(i,1)
+     !        if( trim(chem_isos% name(s% chem_id(i))) == 'prot' .or. trim(chem_isos% name(s% chem_id(i))) == 'neut')then
+     !           continue ! don't count these
+     !        else if( trim(chem_isos% name(s% chem_id(i))) == 'h1' .or. trim(chem_isos% name(s% chem_id(i))) == 'h2' ) then
+     !           initial_X = initial_X + s% xa(i,1)
+     !        else if( trim(chem_isos% name(s% chem_id(i))) == 'he3' .or. trim(chem_isos% name(s% chem_id(i))) == 'he4' ) then
+     !           initial_Y = initial_Y + s% xa(i,1)
+     !        else
+     !           initial_Z = initial_Z + s% xa(i,1)
+     !        endif
+     !     enddo
+     !     initial_m = s% initial_mass
+     !     extra_header_item_names(1) = 'initial_Z'
+     !     extra_header_item_vals(1) = initial_Z
+     !     extra_header_item_names(2) = 'initial_Y'
+     !     extra_header_item_vals(2) =  initial_Y
+     !     extra_header_item_names(3) = 'initial_m'
+     !     extra_header_item_vals(3) =  initial_m
+     ! end subroutine data_for_extra_history_header_items
+    
+      subroutine data_for_extra_history_header_items(id, n, names, vals, ierr)
+         integer, intent(in) :: id, n
+         character (len=maxlen_history_column_name) :: names(n)
+         real(dp) :: vals(n)
+         type(star_info), pointer :: s
+         integer, intent(out) :: ierr
+         integer :: i
+         real(dp) :: Initial_X, Initial_Y, Initial_Z, initial_m
+         ierr = 0
+         call star_ptr(id,s,ierr)
+         if(ierr/=0) return
+    
+         initial_X = 0._dp
+         initial_Y = 0._dp
+         initial_Z = 0._dp
+         initial_m = 0._dp
+         do i=1,s% species
+             !write(*,*) chem_isos% name(s% chem_id(i)), s% xa(i,1)
+             if( trim(chem_isos% name(s% chem_id(i))) == 'prot' .or. trim(chem_isos% name(s% chem_id(i))) == 'neut')then
+                continue ! don't count these
+             else if( trim(chem_isos% name(s% chem_id(i))) == 'h1' .or. trim(chem_isos% name(s% chem_id(i))) == 'h2' ) then
+                initial_X = initial_X + s% xa(i,1)
+             else if( trim(chem_isos% name(s% chem_id(i))) == 'he3' .or. trim(chem_isos% name(s% chem_id(i))) == 'he4' ) then
+                initial_Y = initial_Y + s% xa(i,1)
+             else
+                initial_Z = initial_Z + s% xa(i,1)
+             endif
+          enddo
+          initial_m = s% initial_mass
+          names(1) = 'initial_Z'
+          vals(1) = initial_Z
+          names(2) = 'initial_Y'
+          vals(2) =  initial_Y
+          names(3) = 'initial_m'
+          vals(3) =  initial_m
+      ! here is an example for adding an extra history header item
+      ! also set how_many_extra_history_header_items
+      ! names(1) = 'mixing_length_alpha'
+      ! vals(1) = s% mixing_length_alpha
+    
+      end subroutine data_for_extra_history_header_items
+    
+      integer function how_many_extra_history_columns(id)
+        integer, intent(in) :: id
+        integer :: ierr
+        type (star_info), pointer :: s
+        ierr = 0
+        call star_ptr(id, s, ierr)
+        if (ierr /= 0) return
+        how_many_extra_history_columns = 26
+      end function how_many_extra_history_columns
+    
+      subroutine data_for_extra_history_columns(id, n, names, vals, ierr)
+        use chem_def, only: chem_isos
+        integer, intent(in) :: id, n
+        character (len=maxlen_history_column_name) :: names(n)
+        real(dp) :: vals(n)
+        integer, intent(out) :: ierr
+        type (star_info), pointer :: s
+        real(dp) :: ocz_top_radius, ocz_bot_radius, &
+             ocz_top_mass, ocz_bot_mass, mixing_length_at_bcz, &
+             dr, ocz_turnover_time_g, ocz_turnover_time_l_b, ocz_turnover_time_l_t, &
+             env_binding_E, total_env_binding_E, MoI
+        integer :: i, k, n_conv_bdy, nz, k_ocz_bot, k_ocz_top
+        integer :: i1, k1, k2, j
+        real(dp) :: avg_c_in_c_core
+        integer ::  top_bound_zone, bot_bound_zone
+        real(dp) :: m_env, Dr_env, Renv_middle, tau_conv, tau_conv_new, m_conv_core, f_conv
+        real(dp) :: r_top, r_bottom, m_env_new, Dr_env_new, Renv_middle_new
+        real(dp) :: conv_mx_top, conv_mx_bot, conv_mx_top_r, conv_mx_bot_r, k_div_T_posydon_new, k_div_T_posydon
+          integer :: n_conv_regions_posydon
+          integer,  dimension (max_num_mixing_regions) :: n_zones_of_region, bot_bdy, top_bdy
+          real(dp), dimension (max_num_mixing_regions) :: cz_bot_mass_posydon
+          real(dp) :: cz_bot_radius_posydon(max_num_mixing_regions)
+          real(dp), dimension (max_num_mixing_regions) :: cz_top_mass_posydon, cz_top_radius_posydon
+        integer :: h1, he4, c12, o16
+        real(dp) :: he_core_mass_1cent,  he_core_mass_10cent, he_core_mass_30cent
+        real(dp) :: he_core_radius_1cent, he_core_radius_10cent, he_core_radius_30cent
+        real(dp) ::  lambda_CE_1cent, lambda_CE_10cent, lambda_CE_30cent, lambda_CE_pure_He_star_10cent
+        real(dp),  dimension (:), allocatable ::  adjusted_energy
+        real(dp) :: rec_energy_HII_to_HI, &
+                    rec_energy_HeII_to_HeI, &
+                    rec_energy_HeIII_to_HeII, &
+                    diss_energy_H2, &
+                    frac_HI, frac_HII, &
+                    frac_HeI, frac_HeII, frac_HeIII, &
+                    avg_charge_He, energy_comp
+        real(dp) :: co_core_mass, co_core_radius
+        integer :: co_core_k
+        logical :: sticking_to_energy_without_recombination_corr
+        real(dp) :: XplusY_CO_core_mass_threshold
+        logical :: have_30_value, have_10_value, have_1_value, have_co_value
+    
+        ierr = 0
+        call star_ptr(id, s, ierr)
+        if (ierr /= 0) return
+    
+        ! output info about the CONV. ENV.: the CZ location, turnover time
+        nz = s% nz
+        n_conv_bdy = s% num_conv_boundaries
+        i = s% n_conv_regions
+        k_ocz_bot = 0
+        k_ocz_top = 0
+        ocz_turnover_time_g = 0.0_dp
+        ocz_turnover_time_l_b = 0.0_dp
+        ocz_turnover_time_l_t = 0.0_dp
+        ocz_top_mass = 0.0_dp
+        ocz_bot_mass = 0.0_dp
+        ocz_top_radius = 0.0_dp
+        ocz_bot_radius = 0.0_dp
+    
+        !check the outermost convection zone
+        !if dM_convenv/M < 1d-8, there's no conv env.
+        if (s% n_conv_regions > 0) then
+           if ((s% cz_top_mass(i)/s% mstar > 0.99d0) .and. &
+                ((s% cz_top_mass(i)-s% cz_bot_mass(i))/s% mstar > 1.0d-11)) then
+    
+              ocz_bot_mass = s% cz_bot_mass(i)
+              ocz_top_mass = s% cz_top_mass(i)
+              !get top radius information
+              !start from k=2 (second most outer zone) in order to access k-1
+              do k=2,nz
+                 if (s% m(k) < ocz_top_mass) then
+                    ocz_top_radius = s% r(k-1)
+                    k_ocz_top = k-1
+                    exit
+                 end if
+              end do
+              !get top radius information
+              do k=2,nz
+                 if (s% m(k) < ocz_bot_mass) then
+                    ocz_bot_radius = s% r(k-1)
+                    k_ocz_bot = k-1
+                    exit
+                 end if
+              end do
+    
+              !if the star is fully convective, then the bottom boundary is the center
+              if ((k_ocz_bot == 0) .and. (k_ocz_top > 0)) then
+                 k_ocz_bot = nz
+              end if
+    
+              !compute the "global" turnover time
+              do k=k_ocz_top,k_ocz_bot
+                 if (k==1) cycle
+                 dr = s%r(k-1)-s%r(k)
+                 ocz_turnover_time_g = ocz_turnover_time_g + (dr/s%conv_vel(k))
+              end do
+    
+              !compute the "local" turnover time half of a scale height above the BCZ
+              mixing_length_at_bcz = s% mlt_mixing_length(k_ocz_bot)
+              do k=k_ocz_top,k_ocz_bot
+                 if (s% r(k) < (s% r(k_ocz_bot)+0.5d0*(mixing_length_at_bcz))) then
+                    ocz_turnover_time_l_b = mixing_length_at_bcz/s% conv_vel(k)
+                    exit
+                 end if
+              end do
+    
+              !compute the "local" turnover time one scale height above the BCZ
+              do k=k_ocz_top,k_ocz_bot
+                 if (s% r(k) <  s% r(k_ocz_bot)+mixing_length_at_bcz ) then
+                    ocz_turnover_time_l_t = mixing_length_at_bcz/s% conv_vel(k)
+                    exit
+                 end if
+              end do
+           end if
+        endif
+    
+        names(1) = 'conv_env_top_mass'
+        vals(1) = ocz_top_mass/msun
+        names(2) = 'conv_env_bot_mass'
+        vals(2) = ocz_bot_mass/msun
+        names(3) = 'conv_env_top_radius'
+        vals(3) = ocz_top_radius/rsun
+        names(4) = 'conv_env_bot_radius'
+        vals(4) = ocz_bot_radius/rsun
+        names(5) = 'conv_env_turnover_time_g'
+        vals(5) = ocz_turnover_time_g
+        names(6) = 'conv_env_turnover_time_l_b'
+        vals(6) = ocz_turnover_time_l_b
+        names(7) = 'conv_env_turnover_time_l_t'
+        vals(7) = ocz_turnover_time_l_t
+    
+        ! output info about the ENV.: binding energy
+    
+        total_env_binding_E = 0.0d0
+        do k=1,s% nz - 1
+           if (s% m(k) > (s% he_core_mass * Msun)) then !envelope is defined to be H-rich
+              env_binding_E = s% dm(k) * (s% energy(k) - (s% cgrav(k) * s% m(k+1))/s% r(k+1))
+              total_env_binding_E = total_env_binding_E + env_binding_E
+           end if
+        end do
+    
+        names(8) = 'envelope_binding_energy'
+        vals(8) = total_env_binding_E
+    
+        names(9) = 'total_moment_of_inertia'
+        MoI = 0.0d0
+        if(.not.s% rotation_flag)then
+           do i=s% nz, 2, -1
+              MoI = MoI + 0.4d0*s% dm_bar(i)*(pow5(s% r(i)) - pow5(s% r(i-1)) )/(pow3(s% r(i)) - pow3(s% r(i-1)))
+           enddo
+        else
+           MoI = dot_product(s% dm_bar(1:s% nz), s% i_rot(1:s% nz)%val)
+        endif
+    
+        vals(9) = MoI
+    
+        names(10) = "spin_parameter"
+        vals(10) = clight * s% total_angular_momentum/( standard_cgrav * s% m(1) * s% m(1) )
+    
+        if(s% co_core_k > 0 .and. s% co_core_k < s% nz) then
+            !location of c core
+            k1=s% co_core_k
+            !location of center
+            k2=s% nz
+            !locate Carbon-12 in s% xa
+            do i1=1,s% species
+                 if(chem_isos% Z(s% chem_id(i1))==6 .and. chem_isos% Z_plus_N(s% chem_id(i1))==12)then
+                     j=i1
+                     exit
+                 endif
+            enddo
+            avg_c_in_c_core = dot_product(s% xa(j,k1:k2),s% dq(k1:k2))/sum(s% dq(k1:k2))
+         else
+            avg_c_in_c_core = 0.0d0
+         endif
+         names(11) = "avg_c_in_c_core"
+         vals(11) = avg_c_in_c_core
+    
+    
+    
+         ! more significant covective layer for tides
+         m_conv_core = mass_conv_core(s)
+         m_env = 0.0_dp
+         Dr_env = 0.0_dp
+         Renv_middle = 0.0_dp
+         m_env_new = 0.0_dp
+         Dr_env_new = 0.0_dp
+         Renv_middle_new = 0.0_dp
+         k_div_T_posydon_new = 0.0_dp
+         k_div_T_posydon = 0.0_dp
+         !min_zones_for_convective_tides = 10
+         f_conv = 1.0_dp ! we cannot calculate explicitly eq. 32 of Hurley et al. 2002 in single stars,
+            ! beuse it is based on difference of period and spin in real binaries
+                n_zones_of_region=0
+                bot_bdy=0
+                top_bdy=0
+                cz_bot_mass_posydon=0.0_dp
+                cz_bot_radius_posydon=0.0_dp
+                cz_top_mass_posydon=0.0_dp
+                cz_top_radius_posydon=0.0_dp
+                n_conv_regions_posydon = 0
+    
+                call loop_conv_layers(s,n_conv_regions_posydon, n_zones_of_region, bot_bdy, top_bdy, &
+                cz_bot_mass_posydon, cz_bot_radius_posydon, cz_top_mass_posydon, cz_top_radius_posydon)
+         if (n_conv_regions_posydon > 0) then
+           do k=1, n_conv_regions_posydon ! from inside out
+             if ((cz_bot_mass_posydon(k) / Msun) >=  m_conv_core) then ! if the conv. region is not inside the conv. core
+                  m_env_new = (cz_top_mass_posydon(k) - cz_bot_mass_posydon(k)) / Msun
+                  Dr_env_new = cz_top_radius_posydon(k) - cz_bot_radius_posydon(k) ! depth of the convective layer, length of the eddie
+    ! Corresponding to the Renv term in eq.31 of Hurley et al. 2002
+    ! and to (R-Renv) term in eq. 4 of Rasio et al. 1996  (different notation)
+                Renv_middle_new = 0.5_dp * (cz_top_radius_posydon(k) + cz_bot_radius_posydon(k) ) ! middle of the convective layer
+    ! Corresponding to the (R-0.5d0*Renv) in eq.31 of Hurley et al 2002
+    ! and to the Renv in eq. 4 of Rasio et al. 1996
+    ! where it represented the base of the convective layer (different notation)
+    
+                tau_conv_new = 0.431_dp * pow( m_env_new*Dr_env_new* &
+                  Renv_middle_new/3d0/s% L_phot, one_third) * secyer
+
+                 ! ****************************************************************
+                 !P_tid = 1d0/abs(1d0/porb-s% omega(top_bound_zone)/(2d0*pi))
+                 !f_conv = min(1.0d0, (P_tid/(2d0*tau_conv))**b% tidal_reduction)
+    
+                 ! eq 30 of Hurley et al. 2002, assuming f_conv = 1
+                 ! ****************************************************************
+
+                 k_div_T_posydon_new = (2.0_dp/21.0_dp) * (f_conv/tau_conv_new) * (m_env_new/(s% mstar/Msun))
+                 if (k_div_T_posydon_new >= k_div_T_posydon) then
+                    m_env = m_env_new
+                    Dr_env = Dr_env_new
+                    Renv_middle = Renv_middle_new
+                    k_div_T_posydon = k_div_T_posydon_new
+                   conv_mx_top = s% cz_top_mass(k)/s% mstar !  mass coordinate of top layer
+                   conv_mx_bot = s% cz_bot_mass(k)/s% mstar
+                   conv_mx_top_r = r_top ! in Rsun
+                   conv_mx_bot_r = r_bottom
+                   write(*,'(g0)') 'Single conv_mx_top, conv_mx_bot, conv_mx_top_r, conv_mx_bot_r' , &
+                   conv_mx_top, conv_mx_bot, conv_mx_top_r, conv_mx_bot_r
+                   write(*,'(g0)') 'Single m_env, DR_env, Renv_middle, k/T in conv region ', k ,' is ', &
+                      m_env, Dr_env, Renv_middle, k_div_T_posydon
+                  end if
+              end if
+            end do
+        end if
+        names(12) = "mass_conv_reg_fortides"
+        vals(12) = m_env !in solar units
+        names(13) = "thickness_conv_reg_fortides"
+        vals(13) = Dr_env  !in solar units
+        names(14) = "radius_conv_reg_fortides"
+        vals(14) = Renv_middle !in solar units
+    
+    
+       ! lambda_CE calculation for different core definitions.
+       sticking_to_energy_without_recombination_corr = .true. ! MANOS changed to no calculate recombination energy
+       ! get energy from the EOS and adjust the different contributions from recombination/dissociation to internal energy
+       allocate(adjusted_energy(s% nz))
+       adjusted_energy=0.0d0
+    
+       if (sticking_to_energy_without_recombination_corr) then
+          do k=1, s% nz
+              adjusted_energy(k) = s% energy(k)
+          end do
+       else
+          do k=1, s% nz
+             ! the following lines compute the fractions of HI, HII, HeI, HeII and HeIII
+             ! things like ion_ifneut_H are defined in $MESA_DIR/ionization/public/ionization.def
+             ! this file can be checked for additional ionization output available
+             frac_HI = get_ion_info(s,ion_ifneut_H,k)
+             frac_HII = 1.0d0 - frac_HI
+    
+             ! ionization module provides neutral fraction and average charge of He.
+             ! use these two to compute the mass fractions of HeI and HeII
+             frac_HeI = get_ion_info(s,ion_ifneut_He,k)
+             avg_charge_He = get_ion_info(s,ion_iZ_He,k)
+             ! the following is the solution to the equations
+             !   avg_charge_He = 2*fracHeIII + 1*fracHeII
+             !               1 = fracHeI + fracHeII + fracHeIII
+             frac_HeII = 2d0 - 2d0*frac_HeI - avg_charge_He
+             frac_HeIII = 1d0 - frac_HeII - frac_HeI
+    
+             ! recombination energies from https://physics.nist.gov/PhysRefData/ASD/ionEnergy.html
+             rec_energy_HII_to_HI = avo*13.59843449d0*frac_HII*ev2erg*s% X(k)
+             diss_energy_H2 = avo*4.52d0/2d0*ev2erg*s% X(k)
+             rec_energy_HeII_to_HeI = avo*24.58738880d0*(frac_HeII+frac_HeIII)*ev2erg*s% Y(k)/4d0
+             rec_energy_HeIII_to_HeII = avo*54.4177650d0*frac_HeIII*ev2erg*s% Y(k)/4d0
+    
+             adjusted_energy(k) = s% energy(k) &
+                               - rec_energy_HII_to_HI &
+                               - rec_energy_HeII_to_HeI &
+                               - rec_energy_HeIII_to_HeII &
+                               - diss_energy_H2
+    
+             if (adjusted_energy(k) < 0d0 .or. adjusted_energy(k) > s% energy(k)) then
+              write(*,*) "Error when computing adjusted energy in CE, ", &
+                 "s% energy(k):", s% energy(k), " adjusted_energy, ", adjusted_energy(k)
+                 sticking_to_energy_without_recombination_corr = .true.
+              end if
+    
+              if(.false.) then
+                 ! for debug, check the mismatch between the EOS energy and that of a gas+radiation
+                 energy_comp = 3.0d0*avo*boltzm*s% T(k)/(2*s% mu(k)) + crad*pow4(s% T(k))/s% rho(k) &
+                           + rec_energy_HII_to_HI &
+                           + rec_energy_HeII_to_HeI &
+                           + rec_energy_HeIII_to_HeII &
+                           + diss_energy_H2
+    
+                 write(*,*) "compare energies", k, s%m(k)/Msun, s% energy(k), energy_comp, &
+                      (s% energy(k)-energy_comp)/s% energy(k)
+              end if
+    
+           end do
+        end if
+    
+       he_core_mass_1cent = 0.0d0
+       he_core_mass_10cent = 0.0d0
+       he_core_mass_30cent = 0.0d0
+       !for MS stars = he core is 0, lambda calculated for whole star
+       !for He stars = he core is whole star, lambda calculated for whole star
+    
+       he_core_radius_1cent = 0.0d0
+       he_core_radius_10cent = 0.0d0
+       he_core_radius_30cent = 0.0d0
+    
+       h1 = s% net_iso(ih1)
+       he4 = s% net_iso(ihe4)
+       have_30_value = .false.
+       have_10_value = .false.
+       have_1_value = .false.
+       if (h1 /= 0 .and. he4 /= 0) then
+         do k=1, s% nz
+          if (.not. have_30_value) then
+            if (s% xa(h1,k) <=  0.3d0 .and. &
+              s% xa(he4,k) >= 0.1d0) then
+              he_core_mass_30cent = s% m(k)
+              he_core_radius_30cent = s% r(k)
+              have_30_value = .true.
+            end if
+          end if
+          if (.not. have_10_value) then
+            if (s% xa(h1,k) <= 0.1d0 .and. &
+              s% xa(he4,k) >= 0.1d0) then
+              he_core_mass_10cent = s% m(k)
+              he_core_radius_10cent = s% r(k)
+              have_10_value = .true.
+            end if
+          end if
+          if (.not. have_1_value) then
+            if (s% xa(h1,k) <= 0.01d0 .and. &
+              s% xa(he4,k) >= 0.1d0) then
+              he_core_mass_1cent = s% m(k)
+              he_core_radius_1cent = s% r(k)
+              have_1_value = .true.
+            end if
+          end if
+         end do
+       end if
+    
+       lambda_CE_1cent = lambda_CE(s,adjusted_energy, he_core_mass_1cent)
+       lambda_CE_10cent = lambda_CE(s,adjusted_energy, he_core_mass_10cent)
+       lambda_CE_30cent = lambda_CE(s,adjusted_energy, he_core_mass_30cent)
+    
+       names(15) = 'lambda_CE_1cent'
+       vals(15) = lambda_CE_1cent
+       names(16) = 'lambda_CE_10cent'
+       vals(16) = lambda_CE_10cent
+       names(17) = 'lambda_CE_30cent'
+       vals(17) = lambda_CE_30cent
+    
+       ! CO core:
+       c12 = s% net_iso(ic12)
+       o16 = s% net_iso(io16)
+       XplusY_CO_core_mass_threshold = 0.1d0
+    
+       co_core_k = 0
+       co_core_mass = 0.0d0
+       co_core_radius = 0.0d0
+       have_co_value = .false.
+       if (c12 /= 0 .and. o16 /= 0) then
+         do k=1, s% nz
+          if (.not. have_co_value) then
+            if (((s% xa(h1,k) + s% xa(he4,k))  <= XplusY_CO_core_mass_threshold) .and. &
+              ((s% xa(c12,k) + s% xa(o16,k))  >= XplusY_CO_core_mass_threshold)) then
+              call set_core_info(s, k, co_core_k, &
+              co_core_mass, co_core_radius)
+              have_co_value = .true.
+            end if
+          end if
+         end do
+       end if
+    
+       names(18) = 'co_core_mass'
+       vals(18) = co_core_mass
+       names(19) = 'co_core_radius'
+       vals(19) = co_core_radius
+    
+       lambda_CE_pure_He_star_10cent = lambda_CE(s,adjusted_energy, co_core_mass)
+       names(20) = 'lambda_CE_pure_He_star_10cent'
+       vals(20) = lambda_CE_pure_He_star_10cent
+    
+    
+       names(21) = 'he_core_mass_1cent'
+       vals(21) = he_core_mass_1cent
+       names(22) = 'he_core_mass_10cent'
+       vals(22) = he_core_mass_10cent
+       names(23) = 'he_core_mass_30cent'
+       vals(23) = he_core_mass_30cent
+       names(24) = 'he_core_radius_1cent'
+       vals(24) = he_core_radius_1cent
+       names(25) = 'he_core_radius_10cent'
+       vals(25) = he_core_radius_10cent
+       names(26) = 'he_core_radius_30cent'
+       vals(26) = he_core_radius_30cent
+    
+    
+       deallocate(adjusted_energy)
+      end subroutine data_for_extra_history_columns
+    
+      real(dp) function lambda_CE(s, adjusted_energy, star_core_mass_CE)
+          type (star_info), pointer :: s
+          integer :: k
+          real(dp) :: E_bind, E_bind_shell, star_core_mass_CE
+          real(dp) :: adjusted_energy(:)
+    
+          if (s% m(1) <= (star_core_mass_CE)) then
+             lambda_CE = 1d99 ! no envelope, so immediately have a "succesfull envelope ejection"
+          else
+             E_bind = 0.0d0
+             E_bind_shell = 0.0d0
+             do k=1, s% nz - 1
+                if (s% m(k) > (star_core_mass_CE)) then !envelope is defined as everything above star_core_mass_CE.
+                   E_bind_shell = s% dm(k) * adjusted_energy(k) - (s% cgrav(k) * s% m(k+1) * s% dm(k))/(s% r(k+1))
+                   E_bind = E_bind+ E_bind_shell
+                end if
+             end do
+             lambda_CE = - s% cgrav(1) * (s% m(1)) * ((s% m(1)) - star_core_mass_CE)/(E_bind * s% r(1))
+          end if
+       end function lambda_CE
+       
+       ! Used for Fragos+19, but it does not work with MESA 23.05.1
+       !real(dp) function get_ion_info(s,id,k)
+       !  !use ionization_def, only: num_ion_vals
+       !  !use ionization_lib, only: eval_ionization
+       !  integer, intent(in) :: id, k
+       !  integer :: ierr
+       !  real(dp) :: ionization_res(num_ion_vals)
+       !  type (star_info), pointer :: s
+       !  ierr = 0
+       !  call eval_ionization( &
+       !       1d0 - (s% X(k) + s% Y(k)), s% X(k), s% Rho(k), s% lnd(k)/ln10, &
+       !       s% T(k), s% lnT(k)/ln10, ionization_res, ierr)
+       !  if (ierr /= 0) ionization_res = 0
+       !  get_ion_info = ionization_res(id)
+       !end function get_ion_info
+    
+    
+       ! simpler version of the same function at star/private/report.f90
+       subroutine set_core_info(s, k, &
+             core_k, core_m, core_r)
+          type (star_info), pointer :: s
+          integer, intent(in) :: k
+          integer, intent(out) :: core_k
+          real(dp), intent(out) :: &
+             core_m, core_r
+    
+          integer :: j, jm1, j00
+          real(dp) :: dm1, d00, qm1, q00, core_q, &
+             core_lgP, core_g, core_X, core_Y, core_edv_H, core_edv_He, &
+             core_scale_height, core_dlnX_dr, core_dlnY_dr, core_dlnRho_dr
+    
+          include 'formats'
+    
+          if (k == 1) then
+             core_q = 1d0
+          else
+             jm1 = maxloc(s% xa(:,k-1), dim=1)
+             j00 = maxloc(s% xa(:,k), dim=1)
+             qm1 = s% q(k-1) - 0.5d0*s% dq(k-1) ! center of k-1
+             q00 = s% q(k) - 0.5d0*s% dq(k) ! center of k
+             dm1 = s% xa(j00,k-1) - s% xa(jm1,k-1)
+             d00 = s% xa(j00,k) - s% xa(jm1,k)
+             if (dm1*d00 > 0d0) then
+                write(*,2) 'bad args for set_core_info', k, dm1, d00
+                call mesa_error(__FILE__,__LINE__)
+                core_q = 0.5d0*(qm1 + q00)
+             else if (dm1 == 0d0 .and. d00 == 0d0) then
+                core_q = 0.5d0*(qm1 + q00)
+             else if (dm1 == 0d0) then
+                core_q = qm1
+             else if (d00 == 0d0) then
+                core_q = q00
+             else
+                core_q = find0(qm1, dm1, q00, d00)
+             end if
+          end if
+    
+          call get_info_at_q(s, core_q, &
+             core_k, core_m, core_r)
+    
+       end subroutine set_core_info
+    
+    
+       subroutine get_info_at_q(s, bdy_q, &
+             kbdy, bdy_m, bdy_r)
+    
+          type (star_info), pointer :: s
+          real(dp), intent(in) :: bdy_q
+          integer, intent(out) :: kbdy
+          real(dp), intent(out) :: &
+             bdy_m, bdy_r
+    
+          real(dp) :: x, x0, x1, x2, alfa, beta, bdy_omega_crit
+          integer :: k, ii, klo, khi
+    
+          include 'formats'
+    
+          bdy_m=0.0d0; bdy_r=0.0d0;
+          kbdy = 0
+    
+          if (bdy_q <= 0.0d0) return
+          k = k_for_q(s,bdy_q)
+          if (k >= s% nz) then
+             kbdy = s% nz
+             return
+          end if
+          if (k <= 1) then
+             bdy_m = s% star_mass
+             bdy_r = s% r(1)/Rsun
+             kbdy = 1
+             return
+          end if
+    
+          kbdy = k+1
+    
+          bdy_m = (s% M_center + s% xmstar*bdy_q)/Msun
+    
+          x = s% q(k-1) - bdy_q
+          x0 = s% dq(k-1)/2.0d0
+          x1 = s% dq(k)/2 + s% dq(k-1)
+          x2 = s% dq(k+1)/2.0d0 + s% dq(k) + s% dq(k-1)
+    
+          alfa = max(0d0, min(1d0, (bdy_q - s% q(k+1))/s% dq(k)))
+    
+          bdy_r = pow( &
+             interp2(s% r(k)*s% r(k)*s% r(k), s% r(k+1)*s% r(k+1)*s% r(k+1)),1d0/3d0)/Rsun
+    
+          contains
+    
+          real(dp) function interp2(f0, f1)
+             real(dp), intent(in) :: f0, f1
+             interp2 = alfa*f0 + (1.0d0-alfa)*f1
+          end function interp2
+    
+       end subroutine get_info_at_q
+    
+    
+    
+    
+    
+      real(dp) function mass_conv_core(s)
+          type (star_info), pointer :: s
+          integer :: j, nz, k
+          real(dp) :: dm_limit
+          include 'formats'
+          mass_conv_core = 0.0d0
+          dm_limit = s% conv_core_gap_dq_limit*s% xmstar
+          nz = s% nz
+          do j = 1, s% n_conv_regions
+             ! ignore possible small gap at center
+             if (s% cz_bot_mass(j) <= s% m(nz) + dm_limit) then
+                mass_conv_core = s% cz_top_mass(j)/Msun
+                ! jump over small gaps
+                do k = j+1, s% n_conv_regions
+                   if (s% cz_bot_mass(k) - s% cz_top_mass(k-1) >= dm_limit) exit
+                   mass_conv_core = s% cz_top_mass(k)/Msun
+                end do
+                exit
+             end if
+          end do
+       end function mass_conv_core
+    
+    
+      subroutine how_many_extra_profile_header_items(id, id_extra, num_cols)
+          integer, intent(in) :: id, id_extra
+          integer, intent(out) :: num_cols
+          num_cols=3
+      end subroutine how_many_extra_profile_header_items
+    
+      subroutine data_for_extra_profile_header_items( &
+                      id, id_extra, num_extra_header_items, &
+                      extra_header_item_names, extra_header_item_vals, ierr)
+          use chem_def, only: chem_isos
+          integer, intent(in) :: id, id_extra, num_extra_header_items
+          character (len=*), pointer :: extra_header_item_names(:)
+          real(dp), pointer :: extra_header_item_vals(:)
+          type(star_info), pointer :: s
+          integer, intent(out) :: ierr
+          integer :: i
+          real(dp) :: Initial_X, Initial_Y, Initial_Z, initial_m
+          ierr = 0
+          call star_ptr(id,s,ierr)
+          if(ierr/=0) return
+          !here is an example for adding an extra history header item
+          !set num_cols=1 in how_many_extra_history_header_items and then unccomment these lines
+          initial_X = 0._dp
+          initial_Y = 0._dp
+          initial_Z = 0._dp
+          initial_m = 0._dp
+          do i=1,s% species
+             !write(*,*) chem_isos% name(s% chem_id(i)), s% xa(i,1)
+             if( trim(chem_isos% name(s% chem_id(i))) == 'prot' .or. trim(chem_isos% name(s% chem_id(i))) == 'neut')then
+                continue ! don't count these
+             else if( trim(chem_isos% name(s% chem_id(i))) == 'h1' .or. trim(chem_isos% name(s% chem_id(i))) == 'h2' ) then
+                initial_X = initial_X + s% xa(i,1)
+             else if( trim(chem_isos% name(s% chem_id(i))) == 'he3' .or. trim(chem_isos% name(s% chem_id(i))) == 'he4' ) then
+                initial_Y = initial_Y + s% xa(i,1)
+             else
+                initial_Z = initial_Z + s% xa(i,1)
+             endif
+          enddo
+          initial_m = s% initial_mass
+          extra_header_item_names(1) = 'initial_Z'
+          extra_header_item_vals(1) = initial_Z
+          extra_header_item_names(2) = 'initial_Y'
+          extra_header_item_vals(2) =  initial_Y
+          extra_header_item_names(3) = 'initial_m'
+          extra_header_item_vals(3) =  initial_m
+      end subroutine data_for_extra_profile_header_items
+    
+      integer function how_many_extra_profile_columns(id, id_extra)
+        use star_def, only: star_info
+        integer, intent(in) :: id, id_extra
+        integer :: ierr
+        type (star_info), pointer :: s
+    
+        ierr = 0
+        call star_ptr(id, s, ierr)
+        if (ierr /= 0) return
+        how_many_extra_profile_columns = 0
+    
+      end function how_many_extra_profile_columns
+    
+    
+      subroutine data_for_extra_profile_columns(id, id_extra, n, nz, names, vals, ierr)
+        use star_def, only: star_info, maxlen_profile_column_name
+        integer, intent(in) :: id, id_extra, n, nz
+        character (len=maxlen_profile_column_name) :: names(n)
+        real(dp) :: vals(nz,n)
+        integer, intent(out) :: ierr
+        type (star_info), pointer :: s
+        integer :: k
+        ierr = 0
+        call star_ptr(id, s, ierr)
+        if (ierr /= 0) return
+      end subroutine data_for_extra_profile_columns
+    
+    
+      integer function extras_finish_step(id)
+        !use atm_lib, only: atm_option, atm_option_str
+        !use kap_def, only: kap_lowT_option, lowT_AESOPUS
+        integer, intent(in) :: id
+        integer :: ierr, i
+        real(dp) :: envelope_mass_fraction, L_He, L_tot, min_center_h1_for_diff, &
+             critmass, feh, rot_full_off, rot_full_on, frac2
+        real(dp), parameter :: huge_dt_limit = 3.15d16 ! ~1 Gyr
+        real(dp), parameter :: new_varcontrol_target = 1d-3
+        real(dp), parameter :: Zsol = 0.0142_dp
+        type (star_info), pointer :: s
+        logical :: diff_test1, diff_test2, diff_test3, is_ne_biggest
+        character (len=strlen) :: photoname, stuff
+    
+        ierr = 0
+        call star_ptr(id, s, ierr)
+        if (ierr /= 0) return
+        extras_finish_step = keep_going
+        call store_extra_info(s)
+        if(s% x_logical_ctrl(2)) then ! this should only up for the 2 step of He star formation
+          ! consistent with H-ZAMS definition from Aaron
+          if (s% power_he_burn * Lsun / s% L(1) > 0.985)  extras_finish_step = terminate
+          if (extras_finish_step == terminate) s% termination_code =t_extras_finish_step
+        end if
+    
+        call check_TP(id) !MANOS this was intriduced to calculate have_done_TP locally
+    
+        ! TP-AGB
+        if(TP_AGB_check .and.  have_done_TP)then
+           TP_AGB_check = .false.
+           late_AGB_check = .true.
+           write(*,*) '++++++++++++++++++++++++++++++++++++++++++'
+           write(*,*) 'now at TP-AGB phase, model number ', s% model_number
+           !save a model and photo
+           call star_write_model(id, 'TPAGB.mod', ierr)
+           photoname = 'photos/TPAGB_photo'
+           call star_save_for_restart(id, photoname, ierr)
+           s% delta_lgTeff_limit = -1d0
+           s% delta_lgTeff_hard_limit = -1d0
+           s% delta_lgL_limit = -1d0
+           s% delta_lgL_hard_limit = -1d0
+           s% Blocker_scaling_factor = 2.0d0
+           !s% varcontrol_target = 2.0d0*s% varcontrol_target
+           write(*,*) ' varcontrol_target = ', s% varcontrol_target
+           write(*,*) '++++++++++++++++++++++++++++++++++++++++++'
+           if(s% x_logical_ctrl(1)) then
+              call star_write_profile_info(id, "LOGS1/final_profile.data", ierr)
+           endif
+        endif
+    
+        ! late AGB
+        if(late_AGB_check)then
+           if (s% initial_mass < 8.0d0 .and. s% he_core_mass/s% star_mass > 0.9d0) then
+              write(*,*) '++++++++++++++++++++++++++++++++++++++++++'
+              write(*,*) 'now at late AGB phase, model number ', s% model_number
+              write(*,*) '++++++++++++++++++++++++++++++++++++++++++'
+              s% Blocker_scaling_factor = 5.0d0
+              late_AGB_check=.false.
+              post_AGB_check=.true.
+           endif
+          if(s% x_logical_ctrl(1)) then
+                 call star_write_profile_info(id, "LOGS1/final_profile.data", ierr)
+          endif
+        endif
+    
+        if(post_AGB_check)then
+           if(s% Teff > 3.0d4)then
+              write(*,*) '++++++++++++++++++++++++++++++++++++++++++'
+              write(*,*) 'now at post AGB phase, model number ', s% model_number
+              !save a model and photo
+              call star_write_model(id, 'postAGB.mod', ierr)
+              photoname = 'photos/pAGB_photo'
+              call star_save_for_restart(id, photoname, ierr)
+              if(s% job% extras_lpar(2))then
+                 s% max_abar_for_burning = -1.0d0
+                 write(*,*) 'turn off burning for post-AGB'
+              endif
+              !s% do_element_diffusion = .true.
+              post_AGB_check = .false.
+              pre_WD_check = .true.
+              write(*,*) '++++++++++++++++++++++++++++++++++++++++++'
+           endif
+           if(s% x_logical_ctrl(1)) then
+                  call star_write_profile_info(id, "LOGS1/final_profile.data", ierr)
+           endif
+        endif
+    
+        ! pre-WD
+        if(pre_WD_check)then
+           if(s% Teff < 3.0d4 .and. s% L_surf < 1.0d0)then
+              pre_WD_check = .false.
+              s% do_wd_sedimentation_heating = .true.
+              write(*,*) '++++++++++++++++++++++++++++++++++++++++++++++'
+              write(*,*) 'now at WD phase, model number ', s% model_number
+              !if(s% job% extras_lpar(2))then
+              !   s% max_abar_for_burning = 199
+              !   write(*,*) 'turn burning back on for WDs'
+              !endif
+              !s% do_element_diffusion = .true.
+              !s% which_atm_option = 'WD_tau_25_tables'
+              !call atm_option_str(atm_option(s% which_atm_option,ierr), stuff, ierr)
+              write(*,*) '++++++++++++++++++++++++++++++++++++++++++++++'
+           endif
+           if(s% x_logical_ctrl(1)) then
+                  call star_write_profile_info(id, "LOGS1/final_profile.data", ierr)
+           endif
+        endif
+    
+        ! All stopping criteria are in run_binary_extras.f but we also use one here too for single star runs only
+        ! define STOPPING CRITERION: stopping criterion for C burning exhaustion, massive stars.
+        !if ((s% center_h1 < 1d-4) .and. (s% center_he4 < 5.0d-2) .and. (s% center_c12 < 5.0d-2)) then
+        if(s% x_logical_ctrl(1)) then !check for central carbon depletion, only in case we run single stars.
+          if ((s% center_h1 < 1d-4) .and. (s% center_he4 < 1.0d-4) .and. (s% center_c12 < 1.0d-2)) then
+            write(*,'(g0)') "termination code: Single star depleted carbon, terminating from run_star_extras"
+            extras_finish_step = terminate
+          endif
+          if ((s% center_h1 < 1d-6) .and. (s% initial_mass <= 0.9d0) .and. (s% star_age > 2.0d10) )then
+              ! stopping criterion for TAMS, low mass stars.
+             termination_code_str(t_xtra2) = &
+               'termination code: Single, low-mass star depleted hydrogen, terminating from run_star_extras'
+             s% termination_code = t_xtra2
+             extras_finish_step = terminate
+          endif
+        endif
+    
+        ! check DIFFUSION: to determine whether or not diffusion should happen
+        ! no diffusion for fully convective, post-MS, and mega-old models
+        ! do diffusion during the WD phase
+        min_center_h1_for_diff = 1d-10
+        diff_test1 = abs(s% mass_conv_core - s% star_mass) < 1d-2 !fully convective
+        diff_test2 = s% star_age > 5d10 !really old
+        diff_test3 = .false. !s% center_h1 < min_center_h1_for_diff !past the main sequence
+        if( diff_test1 .or. diff_test2 .or. diff_test3 )then
+           s% diffusion_dt_limit = huge_dt_limit
+        else
+           s% diffusion_dt_limit = original_diffusion_dt_limit
+        end if
+    
+        ! TP-AGB
+        if(have_done_TP) then
+           !termination_code_str(t_xtra2) = 'Reached TPAGB'
+           !s% termination_code = t_xtra2
+           !extras_finish_step = terminate
+           write(*,'(g0)') 'Reached TPAGB'
+        end if
+      end function extras_finish_step
+    
+    
+      subroutine extras_after_evolve(id, ierr)
+        integer, intent(in) :: id
+        integer, intent(out) :: ierr
+        type (star_info), pointer :: s
+        ierr = 0
+        call star_ptr(id, s, ierr)
+        if (ierr /= 0) return
+        if(s% x_logical_ctrl(1)) then !check for central carbon depletion, only in case we run single stars.
+          call star_write_profile_info(id, "LOGS1/final_profile.data", ierr)
+        endif
+      end subroutine extras_after_evolve
+    
+    
+      subroutine alloc_extra_info(s)
+        integer, parameter :: extra_info_alloc = 1
+        type (star_info), pointer :: s
+        call move_extra_info(s,extra_info_alloc)
+      end subroutine alloc_extra_info
+    
+    
+      subroutine unpack_extra_info(s)
+        integer, parameter :: extra_info_get = 2
+        type (star_info), pointer :: s
+        call move_extra_info(s,extra_info_get)
+      end subroutine unpack_extra_info
+    
+    
+      subroutine store_extra_info(s)
+        integer, parameter :: extra_info_put = 3
+        type (star_info), pointer :: s
+        call move_extra_info(s,extra_info_put)
+      end subroutine store_extra_info
+    
+    
+      subroutine move_extra_info(s,op)
+        integer, parameter :: extra_info_alloc = 1
+        integer, parameter :: extra_info_get = 2
+        integer, parameter :: extra_info_put = 3
+        type (star_info), pointer :: s
+        integer, intent(in) :: op
+    
+        integer :: i, j, num_ints, num_dbls, ierr
+    
+        i = 0
+        num_ints = i
+    
+        i = 0
+        num_dbls = i
+    
+        if (op /= extra_info_alloc) return
+        if (num_ints == 0 .and. num_dbls == 0) return
+    
+        ierr = 0
+        call star_alloc_extras(s% id, num_ints, num_dbls, ierr)
+        if (ierr /= 0) then
+           write(*,*) 'failed in star_alloc_extras'
+           write(*,*) 'alloc_extras num_ints', num_ints
+           write(*,*) 'alloc_extras num_dbls', num_dbls
+           stop 1
+        end if
+    
+      contains
+    
+        subroutine move_dbl(dbl)
+          real(dp) :: dbl
+          i = i+1
+          select case (op)
+          case (extra_info_get)
+             dbl = s% extra_work(i)
+          case (extra_info_put)
+             s% extra_work(i) = dbl
+          end select
+        end subroutine move_dbl
+    
+        subroutine move_int(int)
+          integer :: int
+          i = i+1
+          select case (op)
+          case (extra_info_get)
+             int = s% extra_iwork(i)
+          case (extra_info_put)
+             s% extra_iwork(i) = int
+          end select
+        end subroutine move_int
+    
+        subroutine move_flg(flg)
+          logical :: flg
+          i = i+1
+          select case (op)
+          case (extra_info_get)
+             flg = (s% extra_iwork(i) /= 0)
+          case (extra_info_put)
+             if (flg) then
+                s% extra_iwork(i) = 1
+             else
+                s% extra_iwork(i) = 0
+             end if
+          end select
+        end subroutine move_flg
+    
+      end subroutine move_extra_info
+    
+    
+    
+    subroutine loop_conv_layers(s,n_conv_regions_posydon, n_zones_of_region, bot_bdy, top_bdy, &
+          cz_bot_mass_posydon, cz_bot_radius_posydon, cz_top_mass_posydon, cz_top_radius_posydon)
+             type (star_info), pointer :: s
+             ! integer, intent(out) :: ierr
+    
+             logical :: in_convective_region
+             integer :: k, j, nz
+             logical, parameter :: dbg = .false.
+             integer, intent(out) :: n_conv_regions_posydon
+             !integer :: max_num_mixing_regions
+             !max_num_mixing_regions = 100
+             !integer, intent(out), dimension (:), allocatable :: n_zones_of_region, bot_bdy, top_bdy
+             !real(dp),intent(out), dimension (:), allocatable :: cz_bot_mass_posydon, cz_bot_radius_posydon
+             !real(dp),intent(out), dimension (:), allocatable :: cz_top_mass_posydon, cz_top_radius_posydon
+             integer :: min_zones_for_convective_tides
+             integer ::  pot_n_zones_of_region, pot_bot_bdy, pot_top_bdy
+             real(dp) :: pot_cz_bot_mass_posydon, pot_cz_bot_radius_posydon
+             integer, intent(out), dimension (max_num_mixing_regions) :: n_zones_of_region, bot_bdy, top_bdy
+             real(dp),intent(out), dimension (max_num_mixing_regions) :: cz_bot_mass_posydon
+             real(dp),intent(out) :: cz_bot_radius_posydon(max_num_mixing_regions)
+             real(dp),intent(out), dimension (max_num_mixing_regions) :: cz_top_mass_posydon, cz_top_radius_posydon
+    
+             include 'formats'
+             !ierr = 0
+             min_zones_for_convective_tides = 10
+             nz = s% nz
+             n_zones_of_region=0
+             bot_bdy=0
+             top_bdy=0
+             cz_bot_mass_posydon=0.0_dp
+             cz_bot_radius_posydon=0.0_dp
+             cz_top_mass_posydon=0.0_dp
+             cz_top_radius_posydon=0.0_dp
+             n_conv_regions_posydon = 0_dp
+             pot_cz_bot_mass_posydon = 0.0_dp
+             pot_cz_bot_radius_posydon = 0.0_dp
+             pot_bot_bdy = 0.0_dp
+             pot_n_zones_of_region = 0
+    
+             in_convective_region = (s% mixing_type(nz) == convective_mixing)
+             if (in_convective_region) then
+                pot_cz_bot_mass_posydon = s% M_center
+                pot_cz_bot_radius_posydon = 0.0_dp
+                pot_bot_bdy = nz
+             end if
+    
+             !write(*,*) 'initial in_convective_region', in_convective_region
+    
+             do k=nz-1, 2, -1
+                if (in_convective_region) then
+                   if (s% mixing_type(k) /= convective_mixing) then ! top of convective region
+                      pot_top_bdy = k
+                      pot_n_zones_of_region = pot_bot_bdy - pot_top_bdy
+                      if (pot_n_zones_of_region >= min_zones_for_convective_tides) then
+                        if (n_conv_regions_posydon < max_num_mixing_regions) then
+                          n_conv_regions_posydon = n_conv_regions_posydon + 1
+                        end if
+                        cz_top_mass_posydon(n_conv_regions_posydon) = &
+                          s% M_center + (s% q(k) - s% cz_bdy_dq(k))*s% xmstar
+                        cz_bot_mass_posydon(n_conv_regions_posydon) = pot_cz_bot_mass_posydon
+                        cz_top_radius_posydon(n_conv_regions_posydon) = s% r(k)/Rsun
+                        cz_bot_radius_posydon(n_conv_regions_posydon) = pot_cz_bot_radius_posydon
+                        top_bdy(n_conv_regions_posydon) = pot_top_bdy
+                        bot_bdy(n_conv_regions_posydon) = pot_bot_bdy
+                        n_zones_of_region(n_conv_regions_posydon) = pot_n_zones_of_region
+                      end if
+                      in_convective_region = .false.
+                   end if
+                else
+                   if (s% mixing_type(k) == convective_mixing) then ! bottom of convective region
+                      pot_cz_bot_mass_posydon = &
+                        s% M_center + (s% q(k) - s% cz_bdy_dq(k))*s% xmstar
+                      pot_cz_bot_radius_posydon = s% r(k)/Rsun
+                      pot_bot_bdy = k
+                      in_convective_region = .true.
+                   end if
+                end if
+             end do
+             if (in_convective_region) then
+                pot_top_bdy = 1
+                pot_n_zones_of_region = pot_bot_bdy - pot_top_bdy
+                if (pot_n_zones_of_region >= min_zones_for_convective_tides) then
+                  if (n_conv_regions_posydon < max_num_mixing_regions) then
+                    n_conv_regions_posydon = n_conv_regions_posydon + 1
+                  end if
+                  cz_top_mass_posydon(n_conv_regions_posydon) = s% mstar
+                  cz_top_radius_posydon(n_conv_regions_posydon) = s% r(1)/Rsun
+                  top_bdy(n_conv_regions_posydon) = 1
+                  cz_bot_mass_posydon(n_conv_regions_posydon) = pot_cz_bot_mass_posydon
+                  cz_bot_radius_posydon(n_conv_regions_posydon) = pot_cz_bot_radius_posydon
+                  bot_bdy(n_conv_regions_posydon) = pot_bot_bdy
+                  n_zones_of_region(n_conv_regions_posydon) = pot_n_zones_of_region
+               end if
+             end if
+    
+              !write(*,*)
+              !write(*,2) 'set_mixing_info n_conv_regions_posydon', n_conv_regions_posydon
+              !do j = 1, n_conv_regions_posydon
+              !   write(*,2) 'conv region', j, cz_bot_mass_posydon(j)/Msun, cz_top_mass_posydon(j)/Msun
+              !   write(*,2) 'conv region', j, cz_bot_radius_posydon(j), cz_top_radius_posydon(j)
+              !end do
+              !write(*,*)
+          end subroutine loop_conv_layers
+    
+    
+       subroutine TSF(id, ierr)
+    
+        integer, intent(in) :: id
+        integer, intent(out) :: ierr
+        type (star_info), pointer :: s
+        integer :: k,j,op_err,nsmooth,nsmootham
+        real(dp) :: alpha,shearsmooth,nu_tsf,nu_tsf_t,omegac,omegag,omegaa,&
+        omegat,difft,diffm,brunts,bruntsn2,logamnuomega,alphaq
+    
+        call star_ptr(id,s,ierr)
+        if (ierr /= 0) return
+    
+        alpha=1d0
+        nsmooth=5
+        nsmootham=nsmooth-3
+        shearsmooth=1d-30
+        op_err = 0
+    
+        !Calculate shear at each zone, then calculate TSF torque
+        do k=nsmooth+1,s% nz-(nsmooth+1)
+    
+            nu_tsf=1d-30
+            nu_tsf_t=1d-30
+            !Calculate smoothed shear, q= dlnOmega/dlnr
+            shearsmooth = s% omega_shear(k)/(2d0*nsmooth+1d0)
+            do j=1,nsmooth
+                shearsmooth = shearsmooth + (1d0/(2d0*nsmooth+1d0))*( s% omega_shear(k-j) + s% omega_shear(k+j) )
+            end do
+    
+            diffm =  diffmag(s% kap_handle , s% rho(k),s% T(k),s% abar(k),s% zbar(k),op_err) !Magnetic diffusivity
+            difft = 16d0*5.67d-5*pow3(s% T(k))/(3d0*s% opacity(k)*pow2(s% rho(k))*s% Cv(k)) !Thermal diffusivity
+            omegaa = s% omega(k)*pow(shearsmooth*s% omega(k)/sqrt(abs(s% brunt_N2(k))),1d0/3d0) !Alfven frequency at saturation, assuming adiabatic instability
+            omegat = difft*pow2(sqrt(abs(s% brunt_N2(k)))/(omegaa*s% r(k))) !Thermal damping rate assuming adiabatic instability
+            brunts = sqrt(abs( s% brunt_N2_composition_term(k)&
+                    +(s% brunt_N2(k)-s% brunt_N2_composition_term(k))/(1d0 + omegat/omegaa) )) !Suppress thermal part of brunt
+            bruntsn2 = sqrt(abs( s% brunt_N2_composition_term(k)+&
+                (s% brunt_N2(k)-s% brunt_N2_composition_term(k))*min(1d0,diffm/difft) )) !Effective brunt for isothermal instability
+            brunts = max(brunts,bruntsn2) !Choose max between suppressed brunt and isothermal brunt
+            brunts = max(s% omega(k),brunts) !Don't let Brunt be smaller than omega
+            omegaa = s% omega(k)*pow(abs(shearsmooth*s% omega(k)/brunts),1d0/3d0) !Recalculate omegaa
+    
+            ! Calculate nu_TSF
+            if (s% brunt_N2(k) > 0d0) then
+                if (pow2(brunts) > 2d0*pow2(shearsmooth)*pow2(s% omega(k))) then
+                    omegac = 1d0*s% omega(k)*sqrt(brunts/s% omega(k))*pow(diffm/(pow2(s% r(k))*s% omega(k)),0.25d0)  !Critical field strength
+                    nu_tsf = 5d-1+5d-1*tanh(5d0*log(alpha*omegaa/omegac)) !Suppress AM transport if omega_a<omega_c
+                    nu_tsf = nu_tsf*pow3(alpha)*s% omega(k)*pow2(s% r(k))*pow2(s% omega(k)/brunts) !nu_omega for revised Tayler instability
+                end if
+                ! Add TSF enabled by thermal diffusion
+                if (pow2(brunts) < 2d0*pow2(shearsmooth)*pow2(s% omega(k))) then
+                    nu_tsf_t = alpha*abs(shearsmooth)*s% omega(k)*pow2(s% r(k))
+                end if
+                s% am_nu_omega(k) = s% am_nu_omega(k) + max(nu_tsf,nu_tsf_t) + 1d-1
+            end if
+    
+         end do
+    
+    
+          !Values near inner boundary
+          do k=s% nz-nsmooth,s% nz
+            nu_tsf=1d-30
+            nu_tsf_t=1d-30
+            shearsmooth = shearsmooth
+    
+            diffm =  diffmag(s% kap_handle , s% rho(k),s% T(k),s% abar(k),s% zbar(k),op_err) !Magnetic diffusivity
+            difft = 16d0*5.67d-5*pow3(s% T(k))/(3d0*s% opacity(k)*pow2(s% rho(k))*s% Cv(k)) !Thermal diffusivity
+            omegaa = s% omega(k)*pow(shearsmooth*s% omega(k)/sqrt(abs(s% brunt_N2(k))),1d0/3d0) !Alfven frequency at saturation, assuming adiabatic instability
+            omegat = difft*pow2(sqrt(abs(s% brunt_N2(k)))/(s% omega(k)*s% r(k))) !Thermal damping rate assuming adiabatic instability
+            brunts = sqrt(abs( s% brunt_N2_composition_term(k)&
+                +(s% brunt_N2(k)-s% brunt_N2_composition_term(k))/(1d0 + omegat/omegaa) )) !Suppress thermal part of brunt
+            bruntsn2 = sqrt(abs( s% brunt_N2_composition_term(k)+&
+                (s% brunt_N2(k)-s% brunt_N2_composition_term(k))*min(1d0,diffm/difft) )) !Effective brunt for isothermal instability
+            brunts = max(brunts,bruntsn2) !Choose max between suppressed brunt and isothermal brunt
+            brunts = max(s% omega(k),brunts) !Don't let Brunt be smaller than omega
+            omegaa = s% omega(k)*pow(abs(shearsmooth*s% omega(k)/brunts),1d0/3d0) !Recalculate omegaa
+    
+            ! Calculate nu_TSF
+            if (s% brunt_N2(k) > 0d0) then
+                if (pow2(brunts) > 2d0*pow2(shearsmooth)*pow2(s% omega(k))) then
+                    omegac = 1d0*s% omega(k)*sqrt(brunts/s% omega(k))*pow(diffm/(pow2(s% r(k))*s% omega(k)),0.25d0)  !Critical field strength
+                    nu_tsf = 5d-1+5d-1*tanh(5d0*log(alpha*omegaa/omegac)) !Suppress AM transport if omega_a<omega_c
+                    nu_tsf = nu_tsf*pow3(alpha)*s% omega(k)*pow2(s% r(k))*pow2(s% omega(k)/brunts) !nu_omega for revised Tayler instability
+                end if
+                ! Add TSF enabled by thermal diffusion
+                if (pow2(brunts) < 2d0*pow2(shearsmooth)*pow2(s% omega(k))) then
+                    nu_tsf_t = alpha*abs(shearsmooth)*s% omega(k)*pow2(s% r(k))
+                end if
+                s% am_nu_omega(k) = s% am_nu_omega(k) + max(nu_tsf,nu_tsf_t) + 1d-1
+            end if
+          end do
+    
+      !Values near outer boundary
+      do k=nsmooth,1
+        nu_tsf=1d-30
+        nu_tsf_t=1d-30
+        shearsmooth = shearsmooth
+    
+        diffm =  diffmag(s% kap_handle , s% rho(k),s% T(k),s% abar(k),s% zbar(k),op_err) !Magnetic diffusivity
+        difft = 16d0*5.67d-5*pow3(s% T(k))/(3d0*s% opacity(k)*pow2(s% rho(k))*s% Cv(k)) !Thermal diffusivity
+        omegaa = s% omega(k)*pow(shearsmooth*s% omega(k)/sqrt(abs(s% brunt_N2(k))),1d0/3d0) !Alfven frequency at saturation, assuming adiabatic instability
+        omegat = difft*pow2(sqrt(abs(s% brunt_N2(k)))/(s% omega(k)*s% r(k))) !Thermal damping rate assuming adiabatic instability
+        brunts = sqrt(abs( s% brunt_N2_composition_term(k)&
+            +(s% brunt_N2(k)-s% brunt_N2_composition_term(k))/(1d0 + omegat/omegaa) )) !Suppress thermal part of brunt
+        bruntsn2 = sqrt(abs( s% brunt_N2_composition_term(k)+&
+            (s% brunt_N2(k)-s% brunt_N2_composition_term(k))*min(1d0,diffm/difft) )) !Effective brunt for isothermal instability
+        brunts = max(brunts,bruntsn2) !Choose max between suppressed brunt and isothermal brunt
+        brunts = max(s% omega(k),brunts) !Don't let Brunt be smaller than omega
+        omegaa = s% omega(k)*pow(abs(shearsmooth*s% omega(k)/brunts),1d0/3d0) !Recalculate omegaa
+    
+        ! Calculate nu_TSF
+        if (s% brunt_N2(k) > 0d0) then
+            if (pow2(brunts) > 2d0*pow2(shearsmooth)*pow2(s% omega(k))) then
+                omegac = 1d0*s% omega(k)*sqrt(brunts/s% omega(k))*pow(diffm/(pow2(s% r(k))*s% omega(k)),0.25d0)  !Critical field strength
+                nu_tsf = 5d-1+5d-1*tanh(5d0*log(alpha*omegaa/omegac)) !Suppress AM transport if omega_a<omega_c
+                nu_tsf = nu_tsf*pow3(alpha)*s% omega(k)*pow2(s% r(k))*pow2(s% omega(k)/brunts) !nu_omega for revised Tayler instability
+            end if
+            ! Add TSF enabled by thermal diffusion
+            if (pow2(brunts) < 2d0*pow2(shearsmooth)*pow2(s% omega(k))) then
+                nu_tsf_t = alpha*abs(shearsmooth)*s% omega(k)*pow2(s% r(k))
+            end if
+            s% am_nu_omega(k) = s% am_nu_omega(k) + max(nu_tsf,nu_tsf_t) + 1d-1
+        end if
+      end do
+    
+      !Smooth nu_omega
+      logamnuomega=-3d1
+      do k=nsmootham+1,s% nz-(nsmootham+1)
+        !Don't smooth convective diffusivity into non-convective zones
+        if (s% mixing_type(k)==1) then
+            s% am_nu_omega(k) = s% am_nu_omega(k)
+        !Smooth zones if not including a convective zone
+        else
+            logamnuomega = log10(s% am_nu_omega(k))/(2d0*nsmootham+1d0)
+        end if
+        do j=1,nsmootham
+            !Don't smooth convective diffusivity into non-convective zones
+            if (s% mixing_type(k-j)<3.5d0) then
+                logamnuomega = log10(s% am_nu_omega(k))
+            !Smooth zones if not including a convective zone
+            else
+                logamnuomega = logamnuomega + (1d0/(2d0*nsmootham+1d0))*log10(s% am_nu_omega(k-j))
+            end if
+        end do
+        do j=1,nsmootham
+            !Don't smooth convective diffusivity into non-convective zones
+            if (s% mixing_type(k+j)<3.5d0) then
+                logamnuomega = logamnuomega
+            !Smooth zones if not including a convective zone
+            else
+                logamnuomega = logamnuomega + (1d0/(2d0*nsmootham+1d0))*log10(s% am_nu_omega(k+j))
+            end if
+        end do
+        s% am_nu_omega(k) = exp10(logamnuomega)
+      end do
+    
+      !Values near inner boundary
+      do k=s% nz-nsmootham,s% nz
+            s% am_nu_omega(k) = s% am_nu_omega(k-1)
+      end do
+    
+      !Values near outer boundary
+      do k=nsmootham,1
+            s% am_nu_omega(k) = s% am_nu_omega(k-1)
+      end do
+      
+      end subroutine TSF
+    
+    
+    
+      ! the following is a re-implementation of set_mdot in star/private/winds.f90
+      ! that uses Zbase instead of Z
+    
+      subroutine other_set_mdot(id, L_phot, M_phot, R_phot, T_phot, X, Y, Z, wind, ierr)
+        use chem_def
+        use utils_lib
+        integer, intent(in) :: id
+        real(dp), intent(in) :: L_phot, M_phot, R_phot, T_phot, X, Y, Z ! photosphere values (cgs)
+        real(dp), intent(out) :: wind
+        integer, intent(out) :: ierr
+        type (star_info), pointer :: s
+        integer :: k, j, h1, he4, nz, base
+        real(dp) :: max_ejection_mass, alfa, beta, &
+             Zbase, Zsurf, w1, w2, T_high, T_low, L1, M1, R1, T1, &
+             center_h1, center_he4, surface_h1, surface_he4, mdot, &
+             full_off, full_on, cool_wind, hot_wind, divisor
+        character (len=strlen) :: scheme
+        logical :: using_wind_scheme_mdot
+        real(dp), parameter :: Zsolar = 0.019d0 ! for Vink et al formula
+    
+        logical, parameter :: dbg = .false.
+    
+        include 'formats'
+    
+        ierr = 0
+        call star_ptr(id, s, ierr)
+        if(ierr/=0) return
+    
+        Zbase = s% kap_rq% Zbase
+    
+        L1 = L_phot
+        M1 = M_phot
+        T1 = T_phot
+        R1 = R_phot
+    
+        h1 = s% net_iso(ih1)
+        he4 = s% net_iso(ihe4)
+        nz = s% nz
+        wind = 0.0d0
+        using_wind_scheme_mdot = .false.
+    
+        if (h1 > 0) then
+           center_h1 = s% xa(h1,nz)
+           surface_h1 = s% xa(h1,1)
+        else
+           center_h1 = 0.0d0
+           surface_h1 = 0.0d0
+        end if
+        if (he4 > 0.0d0) then
+           center_he4 = s% xa(he4,nz)
+           surface_he4 = s% xa(he4,1)
+        else
+           center_he4 = 0.0d0
+           surface_he4 = 0.0d0
+        end if
+    
+        !massive stars
+        if(s% initial_mass >= 10._dp)then
+           scheme = s% hot_wind_scheme
+           call eval_wind_for_scheme(scheme,wind)
+           if (dbg) write(*,*) 'using hot_wind_scheme: "' // trim(scheme) // '"'
+    
+        !low-mass stars
+        else
+           if(T1 <= s% hot_wind_full_on_T)then
+              !evaluate cool wind
+              !RGB/TPAGB switch goes here
+              if (have_done_TP) then
+                 scheme = s% cool_wind_AGB_scheme
+                 if (dbg) &
+                      write(*,1) 'using cool_wind_AGB_scheme: "' // trim(scheme) // '"', &
+                      center_h1, center_he4, s% RGB_to_AGB_wind_switch
+    
+              else
+                 scheme= s% cool_wind_RGB_scheme
+                 if (dbg) write(*,*) 'using cool_wind_RGB_scheme: "' // trim(scheme) // '"'
+    
+              endif
+              call eval_wind_for_scheme(scheme, cool_wind)
+           endif
+    
+           if(T1 >= s% cool_wind_full_on_T)then
+              !evaluate hot wind
+              scheme="Dutch"
+              call eval_wind_for_scheme(scheme, hot_wind)
+              if (dbg) write(*,*) 'using hot_wind_scheme: "' // trim(scheme) // '"'
+    
+           endif
+    
+           !now we have both hot and cool wind
+    
+           if(T1 < s% cool_wind_full_on_T) then
+              wind = cool_wind
+    
+           elseif(T1 > s% hot_wind_full_on_T) then
+              wind = hot_wind
+    
+           else
+              !now combine the contributions of hot and cool winds
+              divisor = s% hot_wind_full_on_T - s% cool_wind_full_on_T
+              beta = min( (s% hot_wind_full_on_T - T1) / divisor, 1d0)
+              alfa = 1d0 - beta
+              wind = alfa*hot_wind + beta*cool_wind
+           endif
+        endif
+    
+      contains
+    
+        subroutine eval_wind_for_scheme(scheme,wind)
+          character(len=strlen) :: scheme
+          real(dp), intent(out) :: wind
+          include 'formats'
+    
+          wind = 4d-13*(L1*R1/M1)/(Lsun*Rsun/Msun) ! in Msun/year
+          if (dbg) write(*,1) 'wind', wind
+          if (wind <= 0.0d0 .or. is_bad_num(wind)) then
+             ierr = -1
+             write(*,*) 'bad value for wind :', wind,L1,R1,M1
+             if (dbg) stop 'debug: bad value for wind'
+             if (s% stop_for_bad_nums) stop 'winds'
+             return
+          end if
+          !X = surface_h1
+          !Y = surface_he4
+          !Z = Zbase ! previously 1-(X+Y)
+          Zsurf = 1.0_dp - (X+Y)
+    
+          if (scheme == 'Dutch') then
+             T_high = 11000.0d0
+             T_low = 10000.0d0
+             if (s% Dutch_scaling_factor == 0) then
+                wind = 0.0d0
+             else if (T1 <= T_low) then
+                call eval_lowT_Dutch(wind)
+             else if (T1 >= T_high) then
+                call eval_highT_Dutch(wind)
+             else ! transition
+                call eval_lowT_Dutch(w1)
+                call eval_highT_Dutch(w2)
+                alfa = (T1 - T_low)/(T_high - T_low)
+                wind = (1-alfa)*w1 + alfa*w2
+             end if
+             wind = s% Dutch_scaling_factor * wind
+             if(dbg) write(*,1) 'Dutch_wind', wind
+          else if (scheme == 'Reimers') then
+             wind = wind * s% Reimers_scaling_factor
+             if(dbg) write(*,1) 'Reimers_wind', wind
+          else if (scheme == 'Vink') then
+             call eval_Vink_wind(wind)
+             wind = wind * s% Vink_scaling_factor
+             if (dbg) write(*,1) 'Vink_wind', wind
+          else if (scheme == 'Grafener') then
+             call eval_Grafener_wind(wind)
+             wind = wind !* s% Grafener_scaling_factor
+             if (dbg) write(*,1) 'Grafener_wind', wind
+          else if (scheme == 'Blocker') then
+             call eval_blocker_wind(wind)
+             if (dbg) write(*,1) 'Blocker_wind', wind
+          else if (scheme == 'de Jager') then
+             call eval_de_Jager_wind(wind)
+             wind = s% de_Jager_scaling_factor * wind
+             if (dbg) write(*,1) 'de_Jager_wind', wind
+          else if (scheme == 'van Loon') then
+             call eval_van_Loon_wind(wind)
+             wind = s% van_Loon_scaling_factor * wind
+             if (dbg) write(*,1) 'van_Loon_wind', wind
+          else if (scheme == 'Nieuwenhuijzen') then
+             call eval_Nieuwenhuijzen_wind(wind)
+             wind = s% Nieuwenhuijzen_scaling_factor * wind
+             if (dbg) write(*,1) 'Nieuwenhuijzen_wind', wind
+          else
+             ierr = -1
+             write(*,*) 'unknown name for wind scheme : ' // trim(scheme)
+             if (dbg) stop 'debug: bad value for wind scheme'
+             return
+          end if
+    
+          if(s% x_logical_ctrl(3)) then ! Belczynski+2010 LBV2 winds (eq. 8) with factor 1
+            if ((s% center_h1 < 1.0d-4) ) then  ! postMS
+                if ((s% L(1)/Lsun > 6.0d5) .and. &
+                  (1.0d-5 * s% r(1)/Rsun * pow((s% L(1)/Lsun),0.5d0) > 1.0d0)) then ! Humphreys-Davidson limit
+                  wind  = 1.0d-4
+                  if (dbg) write(*,1) 'LBV Belczynski+2010 wind', wind
+                endif
+            endif
+         endif
+    
+        end subroutine eval_wind_for_scheme
+    
+    
+        subroutine eval_Vink_wind(w)
+          real(dp), intent(inout) :: w
+          real(dp) :: alfa, w1, w2, Teff_jump, logMdot, dT, vinf_div_vesc
+    
+          ! alfa = 1 for hot side, = 0 for cool side
+          if (T1 > 27500d0) then
+             alfa = 1
+          else if (T1 < 22500d0) then
+             alfa = 0
+          else ! use Vink et al 2001, eqns 14 and 15 to set "jump" temperature
+             Teff_jump = 1d3*(61.2d0 + 2.59d0*(-13.636d0 + 0.889d0*log10(Z/Zsolar)))
+             dT = 100d0
+             if (T1 > Teff_jump + dT) then
+                alfa = 1
+             else if (T1 < Teff_jump - dT) then
+                alfa = 0
+             else
+                alfa = (T1 - (Teff_jump - dT)) / (2*dT)
+             end if
+          end if
+    
+    
+          if(dbg) write(*,*) 'vink alfa = ', alfa, T1
+    
+          if (alfa > 0.0d0) then ! eval hot side wind (eqn 24)
+             vinf_div_vesc = 2.6d0 ! this is the hot side galactic value
+             vinf_div_vesc = vinf_div_vesc*pow(Z/Zsolar,0.13d0) ! corrected for Z
+             logMdot = &
+                  - 6.697d0 &
+                  + 2.194d0*log10(L1/Lsun/1d5) &
+                  - 1.313d0*log10(M1/Msun/30d0) &
+                  - 1.226d0*log10(vinf_div_vesc/2d0) &
+                  + 0.933d0*log10(T1/4d4) &
+                  - 10.92d0*pow2(log10(T1/4d4)) &
+                  + 0.85d0*log10(Z/Zsolar)
+             w1 = exp10(logMdot)
+          else
+             w1 = 0d0
+          end if
+    
+          if (alfa < 1) then ! eval cool side wind (eqn 25)
+             vinf_div_vesc = 1.3d0 ! this is the cool side galactic value
+             vinf_div_vesc = vinf_div_vesc*pow(Z/Zsolar,0.13d0) ! corrected for Z
+             logMdot = &
+                  - 6.688d0 &
+                  + 2.210d0*log10(L1/Lsun/1d5) &
+                  - 1.339d0*log10(M1/Msun/30d0) &
+                  - 1.601d0*log10(vinf_div_vesc/2d0) &
+                  + 1.07d0*log10(T1/2d4) &
+                  + 0.85d0*log10(Z/Zsolar)
+             w2 = exp10(logMdot)
+          else
+             w2 = 0d0
+          end if
+    
+          w = alfa*w1 + (1d0 - alfa)*w2
+    
+          if (dbg) write(*,*) 'vink wind', w
+    
+        end subroutine eval_Vink_wind
+    
+    
+        subroutine eval_Grafener_wind(w)
+          ! Grafener, G. & Hamann, W.-R. 2008, A&A 482, 945
+          ! routine contributed by Nilou Afsari
+          real(dp), intent(inout) :: w
+          real(dp) :: w1, logMdot, gamma_edd, xsurf, beta, gammazero, lgZ
+          xsurf = surface_h1
+          gamma_edd = exp10(-4.813d0)*(1+xsurf)*(L1/Lsun)*(Msun/M1)
+          lgZ = log10(Z/Zsolar)
+          beta = 1.727d0 + 0.250d0*lgZ
+          gammazero = 0.326d0 - 0.301d0*lgZ - 0.045d0*lgZ*lgZ
+          logMdot = &
+               + 10.046d0 &
+               + beta*log10(gamma_edd - gammazero) &
+               - 3.5d0*log10(T1) &
+               + 0.42d0*log10(L1/Lsun) &
+               - 0.45d0*xsurf
+          w = exp10(logMdot)
+          if (dbg) write(*,*) 'grafener wind', w
+        end subroutine eval_Grafener_wind
+    
+    
+        subroutine eval_blocker_wind(w)
+          real(dp), intent(inout) :: w
+          w = w * s% Blocker_scaling_factor * &
+               4.83d-9 * pow(M1/Msun,-2.1d0) * pow(L1/Lsun,2.7d0)
+          if (dbg) write(*,*) 'blocker wind', w
+        end subroutine eval_blocker_wind
+    
+    
+        subroutine eval_highT_Dutch(w)
+          real(dp), intent(out) :: w
+          include 'formats'
+          if (surface_h1 < 0.4d0) then ! helium rich Wolf-Rayet star: Nugis & Lamers
+             w = 1d-11 * pow(L1/Lsun,1.29d0) * pow(Y,1.7d0) * sqrt(Zsurf)
+             if (dbg) write(*,1) 'Dutch_wind = Nugis & Lamers', log10(wind)
+          else
+             call eval_Vink_wind(w)
+          end if
+        end subroutine eval_highT_Dutch
+    
+    
+        subroutine eval_lowT_Dutch(w)
+          real(dp), intent(out) :: w
+          include 'formats'
+          if (s% Dutch_wind_lowT_scheme == 'de Jager') then
+             call eval_de_Jager_wind(w)
+             if (dbg) write(*,1) 'Dutch_wind = de Jager', safe_log10(wind), T1, T_low, T_high
+          else if (s% Dutch_wind_lowT_scheme == 'van Loon') then
+             call eval_van_Loon_wind(w)
+             if (dbg) write(*,1) 'Dutch_wind = van Loon', safe_log10(wind), T1, T_low, T_high
+          else if (s% Dutch_wind_lowT_scheme == 'Nieuwenhuijzen') then
+             call eval_Nieuwenhuijzen_wind(w)
+             if (dbg) write(*,1) 'Dutch_wind = Nieuwenhuijzen', safe_log10(wind), T1, T_low, T_high
+          else
+             write(*,*) 'unknown value for Dutch_wind_lowT_scheme ' // &
+                  trim(s% Dutch_wind_lowT_scheme)
+             w = 0d0
+          end if
+        end subroutine eval_lowT_Dutch
+    
+    
+        subroutine eval_de_Jager_wind(w)
+          ! de Jager, C., Nieuwenhuijzen, H., & van der Hucht, K. A. 1988, A&AS, 72, 259.
+          real(dp), intent(out) :: w
+          real(dp) :: log10w
+          include 'formats'
+          log10w = 1.769d0*log10(L1/Lsun) - 1.676d0*log10(T1) - 8.158d0
+          w = exp10(log10w)
+          if (dbg) then
+             write(*,1) 'de_Jager log10 wind', log10w
+          end if
+        end subroutine eval_de_Jager_wind
+    
+    
+        subroutine eval_van_Loon_wind(w)
+          ! van Loon et al. 2005, A&A, 438, 273
+          real(dp), intent(out) :: w
+          real(dp) :: log10w
+          include 'formats'
+          log10w = -5.65d0 + 1.05d0*log10(L1/(1d4*Lsun)) - 6.3d0*log10(T1/35d2)
+          w = exp10(log10w)
+        end subroutine eval_van_Loon_wind
+    
+    
+        subroutine eval_Nieuwenhuijzen_wind(w)
+          ! Nieuwenhuijzen, H.; de Jager, C. 1990, A&A, 231, 134 (eqn 2)
+          real(dp), intent(out) :: w
+          real(dp) :: log10w
+          include 'formats'
+          log10w = -14.02d0 + &
+               1.24d0*log10(L1/Lsun) + &
+               0.16d0*log10(M1/Msun) + &
+               0.81d0*log10(R1/Rsun)
+          w = exp10(log10w)
+          if (dbg) then
+             write(*,1) 'Nieuwenhuijzen log10 wind', log10w
+          end if
+        end subroutine eval_Nieuwenhuijzen_wind
+    
+      end subroutine other_set_mdot
+    
+    
+    
+    
+    
+    
+    
+    
+    
+      real(dp) function diffmag(handle , rho,T,abar,zbar,ierr)
+    
+         ! Written by S.-C. Yoon, Oct. 10, 2003
+         ! Electrical conductivity according to Spitzer 1962
+         ! See also Wendell et al. 1987, ApJ 313:284
+         real(dp), intent(in) :: rho, T, abar, zbar
+         integer, intent(out) :: ierr
+         real(dp) :: xmagfmu, xmagft, xmagfdif, xmagfnu, &
+            xkap, xgamma, xlg, xsig1, xsig2, xsig3, xxx, ffff, xsig, &
+            xeta
+         integer, intent(in) :: handle ! from alloc_kap_handle; in star, pass s% kap_handle (see kap_lib.f90)
+    
+        xgamma = 0.2275d0*zbar*zbar*pow(rho*1d-6/abar,1d0/3d0)*1d8/T
+        xlg = log10(xgamma)
+        if (xlg < -1.5d0) then
+            xsig1 = sige1(zbar,T,xgamma)
+            xsig = xsig1
+        else if (xlg >= -1.5d0 .and. xlg <= 0d0) then
+            xxx = (xlg + 0.75d0)*4d0/3d0
+            ffff = 0.25d0*(2d0-3d0*xxx + xxx*xxx*xxx)
+            xsig1 = sige1(zbar,T,xgamma)
+    
+            xsig2 = sige2(handle, T,rho,zbar,ierr)
+            if (ierr /= 0) return
+    
+            xsig = (1d0-ffff)*xsig2 + ffff*xsig1
+        else if (xlg > 0d0 .and. xlg < 0.5d0) then
+            xsig2 = sige2(handle,T,rho,zbar,ierr)
+            if (ierr /= 0) return
+    
+            xsig = xsig2
+        else if (xlg >= 0.5d0 .and. xlg < 1d0) then
+            xxx = (xlg-0.75d0)*4d0
+            ffff = 0.25d0*(2d0-3d0*xxx + xxx*xxx*xxx)
+            xsig2 = sige2(handle ,T,rho,zbar,ierr)
+            if (ierr /= 0) return
+    
+            xsig3 = sige3(zbar,T,xgamma)
+            xsig = (1d0-ffff)*xsig3 + ffff*xsig2
+        else
+            xsig3 = sige3(zbar,T,xgamma)
+            xsig = xsig3
+        endif
+    
+        diffmag = 7.1520663d19/xsig ! magnetic diffusivity
+    
+      end function diffmag
+    
+    
+      ! Helper functions
+    
+      !real(dp) function sqrt(x)
+      !  real(dp), intent(in) :: x
+      !  sqrt_cr = pow_cr(x, 0.5d0)
+      !end function sqrt_cr
+    
+      real(dp) function sige1(z,t,xgamma)
+         ! Written by S.-C. Yoon, Oct. 10, 2003
+         ! Electrical conductivity according to Spitzer 1962
+         ! See also Wendell et al. 1987, ApJ 313:284
+         real(dp), intent(in) :: z, t, xgamma
+         real(dp) :: etan, xlambda,f
+         if (t >= 4.2d5) then
+            f = sqrt(4.2d5/t)
+         else
+            f = 1d0
+         end if
+         xlambda = sqrt(3d0*z*z*z)*pow(xgamma,-1.5d0)*f + 1d0
+         etan = 3d11*z*log(xlambda)*pow(t,-1.5d0)             ! magnetic diffusivity
+         etan = etan/(1d0-1.20487d0*exp(-1.0576d0*pow(z,0.347044d0))) ! correction: gammae
+         sige1 = clight*clight/(4d0*pi*etan)                    ! sigma = c^2/(4pi*eta)
+      end function sige1
+    
+    
+      real(dp) function sige2(handle, T,rho,zbar,ierr)
+         ! writen by S.-C. YOON Oct. 10, 2003
+         ! electrical conductivity using conductive opacity
+         ! see Wendell et al. 1987 ApJ 313:284
+         use kap_lib, only: kap_get_elect_cond_opacity
+         integer, intent(in) :: handle ! from alloc_kap_handle; in star, pass s% kap_handle (see kap_lib.f90)
+         real(dp), intent(in) :: t,rho,zbar
+         integer, intent(out) :: ierr
+         real(dp) :: kap, dlnkap_dlnRho, dlnkap_dlnT
+         call kap_get_elect_cond_opacity(  handle, &
+            zbar, log10(rho), log10(T),  &
+            kap, dlnkap_dlnRho, dlnkap_dlnT, ierr)
+         sige2 = 1.11d9*T*T/(rho*kap)
+      end function sige2
+    
+      real(dp) function sige3(z,t,xgamma)
+         ! writen by S.-C. YOON Oct. 10, 2003
+         ! electrical conductivity in degenerate matter,
+         ! according to Nandkumar & Pethick (1984)
+         real(dp), intent(in) :: z, t, xgamma
+         real(dp) :: rme, rm23, ctmp, xi
+         rme = 8.5646d-23*t*t*t*xgamma*xgamma*xgamma/pow5(z)  ! rme = rho6/mue
+         rm23 = pow(rme,2d0/3d0)
+         ctmp = 1d0 + 1.018d0*rm23
+         xi= sqrt(3.14159d0/3d0)*log(z)/3d0 + 2d0*log(1.32d0+2.33d0/sqrt(xgamma))/3d0-0.484d0*rm23/ctmp
+         sige3 = 8.630d21*rme/(z*ctmp*xi)
+      end function sige3
+    
+      integer function k_for_q(s, q)
+             ! return k s.t. q(k) >= q > q(k)-dq(k)
+             type (star_info), pointer :: s
+             real(dp), intent(in) :: q
+             integer :: k, nz
+             nz = s% nz
+             if (q >= 1.0d0) then
+                k_for_q = 1; return
+             else if (q <= s% q(nz)) then
+                k_for_q = nz; return
+             end if
+             do k = 1, nz-1
+                if (q > s% q(k+1)) then
+                   k_for_q = k; return
+                end if
+             end do
+             k_for_q = nz
+      end function k_for_q
+    
+    
+      subroutine check_TP(id) ! check for AGB thermal pulse dredge up                                                                                                                       
+                !logical, intent(in) :: burn_h, burn_he, burn_z
+                !integer, intent(out) :: ierr
+                !real(dp) :: h, hstep, h2, dr, dr2, dr_limit, r_limit, Bp1
+                !logical :: have_done_TP
+                !integer :: TP_state, TP_M_H_on, TP_M_H_min, TP_count
+                integer, intent(in) :: id
+                integer :: ierr
+                real(dp) :: h1_czb_dm, h1_czb_mass_old
+                type (star_info), pointer :: s        
+                logical, parameter :: dbg = .false.
+                integer, parameter :: max_DUP_counter = 200
+                include 'formats'
+                
+                ierr = 0
+        call star_ptr(id, s, ierr)
+        if (ierr /= 0) return
+    
+                if (s% power_h_burn + s% power_he_burn < 0.5d0*s% power_nuc_burn) then
+                   if (dbg .and.  TP_state /= 0) then
+                      write(*,*) 'advanced burning: change to TP_state = 0'
+                      write(*,*)
+                   end if
+                   TP_state = 0
+                else if (s% he_core_mass > s% co_core_mass + 0.1d0) then
+                   if (dbg .and. TP_state /= 0) then
+                      write(*,*) 'not yet: change to TP_state = 0'
+                      write(*,1) 's% he_core_mass', s% he_core_mass
+                      write(*,1) 's% co_core_mass', s% co_core_mass
+                      write(*,1) 'h1 - co_core_mass', s% he_core_mass - s% co_core_mass
+                      write(*,*)
+                   end if
+                   TP_state = 0
+                else if (TP_state == 0) then ! not in TP                                                                                                                                                                                                                                                                                                                   
+                          if (s% power_he_burn > s% power_h_burn) then ! starting TP                                                                                                                                                                                                                                                                                                 
+                      TP_state = 1
+                      TP_M_H_on = s% h1_czb_mass
+                      TP_M_H_min = s% h1_czb_mass
+                      if (dbg) then
+                         write(*,*) 'change to TP_state = 1'
+                         write(*,1) 'TP_M_H_on',  TP_M_H_on
+                         write(*,*)
+                      end if
+                   end if
+                else
+                   h1_czb_dm = s% h1_czb_mass*1d-6
+                   if (TP_state == 1) then ! early part of TP                                                                                                                                                                                                                                                                                                              
+                      if (s% h1_czb_mass <  TP_M_H_on - h1_czb_dm) then
+                         if (dbg) then
+                            write(*,*) 'change to TP_state = 2'
+                            write(*,1) 's% TP_M_H_on', TP_M_H_on
+                            write(*,1) 'h1_czb_dm', h1_czb_dm
+                            write(*,1) 's% TP_M_H_on - h1_czb_dm',  TP_M_H_on - h1_czb_dm
+                            write(*,1) 'h1_czb_mass', s% h1_czb_mass
+                            write(*,1) '(s% TP_M_H_on - h1_czb_dm) - h1_czb_mass', &
+                               (TP_M_H_on - h1_czb_dm) - s% h1_czb_mass
+                                            write(*,*)
+                         end if
+                                      TP_state = 2
+                                      TP_count = 0
+                         TP_M_H_min = s% h1_czb_mass
+                         have_done_TP = .true.
+                         ! MANOS to replace s% h1_czb_mass_old which does not exist any more in the new MESA version
+                         h1_czb_mass_old = s% h1_czb_mass*Msun
+                      else if (s% power_h_burn > s% power_he_burn) then ! no dredge up                                                                                                                                                                                                                                                                                       
+                         if (dbg) write(*,*) 'change to TP_state = 0: no dredge up this time'
+                         TP_state = 0
+                      end if
+                   else if (TP_state == 2) then ! dredge up part of TP                                                                                                                                                                                                                                                                                                     
+                      if (s% h1_czb_mass < TP_M_H_min)  TP_M_H_min = s% h1_czb_mass
+                      ! h1_czb_mass_old = s% h1_czb_mass_old*Msun ! MANOS commented
+                      if (dbg) then
+                         write(*,1) '(h1_czb_mass - h1_czb_mass_old)/Msun', &
+                            (s% h1_czb_mass - h1_czb_mass_old)/Msun
+                         write(*,1) 'h1_czb_dm/Msun', h1_czb_dm/Msun
+                         write(*,*)
+                      end if
+                      if (s% h1_czb_mass > h1_czb_mass_old + h1_czb_dm .or. &
+                            s% power_h_burn > s% power_he_burn) then
+                         TP_count = TP_count + 1
+                         if (dbg) write(*,2) '++ TP_count',  TP_count, &
+                               s% h1_czb_mass - (h1_czb_mass_old + h1_czb_dm), &
+                              s%  h1_czb_mass,  h1_czb_mass_old + h1_czb_dm, &
+                               h1_czb_mass_old, h1_czb_dm
+                      else if (s% h1_czb_mass < h1_czb_mass_old - h1_czb_dm) then
+                         TP_count = max(0, TP_count - 1)
+                         if (dbg) write(*,3) '-- TP_count',  TP_count,  TP_state
+                      end if
+                      if ( TP_count >  max_DUP_counter) then
+                         if (dbg) write(*,*) 'change to TP_state = 0'
+                         TP_state = 0
+                      end if
+                   end if
+                   if (TP_state == 2) then
+                      !f_below = f_below*s% overshoot_below_noburn_shell_factor
+                      !f0_below = f0_below*s% overshoot_below_noburn_shell_factor
+                   end  if
+                end if
+             end subroutine check_TP
+
+
+              ! ************************************************
+              ! get_ion_info extracted from previous mesa commit
+               real(dp) function get_ion_info(s,id,k)
+               use ionization_def, only: num_ion_vals
+               use ionization_lib, only: eval_ionization
+               integer, intent(in) :: id, k
+               integer :: ierr
+               real(dp) :: ionization_res(num_ion_vals)
+               type (star_info), pointer :: s
+               ierr = 0
+               call eval_ionization( &
+                     1d0 - (s% X(k) + s% Y(k)), s% X(k), s% Rho(k), s% lnd(k)/ln10, &
+                     s% T(k), s% lnT(k)/ln10, ionization_res, ierr)
+               if (ierr /= 0) ionization_res = 0
+               get_ion_info = ionization_res(id)
+               end function get_ion_info
+
+    
+    end module run_star_extras

--- a/step1_InitialModel_Binary/inlist
+++ b/step1_InitialModel_Binary/inlist
@@ -1,8 +1,8 @@
 
 &binary_job
 
-      read_extra_binary_job_inlist1 = .true.
-      extra_binary_job_inlist1_name = 'inlist_project'
+      read_extra_binary_job_inlist(1) = .true.
+      extra_binary_job_inlist_name(1) = 'inlist_project'
 
 / ! end of star_job namelist
 
@@ -10,16 +10,16 @@
 
 &binary_controls
 
-      read_extra_binary_controls_inlist1 = .true.
-      extra_binary_controls_inlist1_name = 'inlist_project'
+      read_extra_binary_controls_inlist(1) = .true.
+      extra_binary_controls_inlist_name(1) = 'inlist_project'
 
 / ! end of controls namelist
 
 
 
-&binary_pgstar
+&pgbinary
 
-      read_extra_binary_pgstar_inlist1 = .true.
-      extra_binary_pgstar_inlist1_name = 'inlist_project'
+      read_extra_pgbinary_inlist(1) = .true.
+      extra_pgbinary_inlist_name(1) = 'inlist_project'
 
-/ ! end of pgstar namelist
+/ ! end of pgbinary namelist

--- a/step1_InitialModel_Binary/inlist1
+++ b/step1_InitialModel_Binary/inlist1
@@ -35,6 +35,7 @@
       !use jina
       !set_rates_preference = .true.
       !new_rates_preference = 2
+      pgstar_flag = .true.
 
 / ! end of star_job namelist
 
@@ -67,6 +68,7 @@
 &controls
       zams_filename = './zams_z1.42m2_y0.2703.data' !POSYDON ZAMS files
       initial_z = 1.42d-2
+      initial_y = 2.7029999999999998D-01
 
       warn_when_large_rel_run_E_err = 1d99
       !warn_when_stop_checking_residuals = .false.
@@ -152,7 +154,7 @@
       am_gradmu_factor = 0.05d0 !f_mu = 0.05 in Heger+2000, 0.1 in Yoon+2006
 
       am_nu_ST_factor = 1.0d0 ! 0:noTS, 1:TS
-      !use_other_am_mixing = .true. ! use this if you want to use the enhanced FULLER et al. TAYLER-SPRUIT
+      use_other_am_mixing = .true. ! use this if you want to use the enhanced FULLER et al. TAYLER-SPRUIT
       !am_time_average = .true.
       premix_omega = .true.
       recalc_mixing_info_each_substep = .true.
@@ -268,3 +270,254 @@ delta_HR_ds_L = 0.125d0
       x_logical_ctrl(3) = .false.
 
 / ! end of controls namelist
+
+&pgstar
+    ! pause = .true.
+    pgstar_show_age_in_years = .true. 
+    pgstar_show_title = .false.
+
+    ! *********************************
+    ! ***** general grid controls *****
+    ! *********************************
+             
+    !file_white_on_black_flag = .false.
+    !win_white_on_black_flag = .false.
+    Grid2_win_flag = .true.
+    Grid2_num_cols = 16 ! divide plotting region into this many equal width cols
+    Grid2_num_plots = 8
+    Grid2_num_rows = 9 
+    Grid2_win_width = 16
+    ! Grid2_win_width = 19
+    Grid2_win_aspect_ratio = 0.65 ! aspect_ratio = height/width
+    Grid2_xleft = 0.04 ! fraction of full window width for margin on left
+    Grid2_xright = 0.96 ! fraction of full window width for margin on right
+    Grid2_ybot = 0.02 ! fraction of full window width for margin on bottom
+    Grid2_ytop = 0.95 ! fraction of full window width for margin on top
+    Grid2_file_flag = .true.
+    Grid2_file_dir = 'png2'
+    Grid2_file_prefix = 'Grid2'
+    Grid2_file_interval = 30 
+    Grid2_file_width = 21
+    Grid2_file_aspect_ratio = 0.6
+
+
+    ! ***********************************
+    ! ***** central conditions plot *****
+    ! ***********************************
+    Grid2_plot_name(1) = 'TRho_Profile'
+    Grid2_plot_row(1) = 7
+    Grid2_plot_rowspan(1) = 3
+    Grid2_plot_col(1) = 9 
+    Grid2_plot_colspan(1) = 3 
+    Grid2_plot_pad_left(1) = 0.0
+    Grid2_plot_pad_right(1) = 0.0
+    Grid2_plot_pad_top(1) = 0.06
+    Grid2_plot_pad_bot(1) = 0.03
+    Grid2_txt_scale_factor(1) = 0.5 
+    show_TRho_Profile_legend = .true.      
+    show_TRho_Profile_eos_regions = .true.=.false.
+    show_TRho_annotation1 = .true.
+    show_TRho_annotation2 = .true.
+    show_TRho_annotation3 = .true.
+    show_TRho_degeneracy_line = .true.    
+
+ 
+    ! **********************
+    ! ***** HR diagram *****
+    ! **********************
+    Grid2_plot_name(2) = 'HR'
+    Grid2_plot_row(2) = 5
+    Grid2_plot_rowspan(2) = 5
+    Grid2_plot_col(2) = 1
+    Grid2_plot_colspan(2) = 5
+    Grid2_plot_pad_left(2) = 0.0
+    Grid2_plot_pad_right(2) = 0.03
+    Grid2_plot_pad_top(2) = 0.05
+    Grid2_plot_pad_bot(2) = 0.05
+    Grid2_txt_scale_factor(2) = 0.5
+
+
+
+    ! ******************************
+    ! ***** Kippenhahn diagram *****
+    ! ******************************
+
+    Grid2_plot_name(3) = 'Kipp'
+    Grid2_plot_row(3) = 0
+    Grid2_plot_rowspan(3) = 5
+    Grid2_plot_col(3) = 1 
+    Grid2_plot_colspan(3) = 5
+    Grid2_plot_pad_left(3) = 0.00
+    Grid2_plot_pad_right(3) = 0.02
+    Grid2_plot_pad_top(3) = 0.06
+    Grid2_plot_pad_bot(3) = 0.05
+    Grid2_txt_scale_factor(3) = 0.5
+
+    !Grid2_Kipp_show_burn(3) = .true.
+
+
+
+    ! **************************
+    ! ***** Text summaries *****
+    ! **************************
+
+    Grid2_plot_name(4) = 'Text_Summary1'
+    Grid2_plot_row(4) =0 
+    Grid2_plot_rowspan(4) = 3
+    Grid2_plot_col(4) = 6
+    Grid2_plot_colspan(4) = 2
+    Grid2_plot_pad_left(4) = 0.0
+    Grid2_plot_pad_right(4) =0.0
+    Grid2_plot_pad_top(4) = 0.05
+    Grid2_plot_pad_bot(4) = 0.0
+    Grid2_txt_scale_factor(4) = 0.14 
+    Text_Summary1_num_rows = 12
+    Text_Summary1_num_cols = 1
+    Text_Summary1_name(:,:) = ''
+
+    Text_Summary1_name(1,1) = 'model_number'
+    Text_Summary1_name(2,1) = 'log_star_age'
+    Text_Summary1_name(3,1) = 'log_dt'
+    Text_Summary1_name(4,1) = 'num_zones'
+    Text_Summary1_name(5,1) = 'num_retries'
+    ! Text_Summary1_name(6,1) = 'num_backups'
+    Text_Summary1_name(7,1) = 'star_mass'
+    Text_Summary1_name(8,1) = 'log_abs_mdot'
+    Text_Summary1_name(9,1) = 'log_L'
+    Text_Summary1_name(10,1) = 'log_Teff'
+    Text_Summary1_name(11,1) = 'log_R'
+    Text_Summary1_name(12,1) = 'log_g'
+
+    Grid2_plot_name(5) = 'Text_Summary2'
+    Grid2_plot_row(5) =3 
+    Grid2_plot_rowspan(5) = 3
+    Grid2_plot_col(5) = 6
+    Grid2_plot_colspan(5) = 2
+    Grid2_plot_pad_left(5) = 0.0
+    Grid2_plot_pad_right(5) =0.0
+    Grid2_plot_pad_top(5) = 0.05
+    Grid2_plot_pad_bot(5) = 0.0
+    Grid2_txt_scale_factor(5) = 0.14 
+    Text_Summary2_num_rows = 12
+    Text_Summary2_num_cols = 1
+    Text_Summary2_name(:,:) = ''
+
+    Text_Summary2_name(1,1) = 'log_Lnuc'
+    Text_Summary2_name(2,1) = 'log_Lneu'
+    Text_Summary2_name(3,1) = 'log_LHe'
+    Text_Summary2_name(4,1) = 'log_LZ'
+    Text_Summary2_name(5,1) = 'log_cntr_T'
+    Text_Summary2_name(6,1) = 'center_h1'
+    Text_Summary2_name(7,1) = 'center_he4'
+    Text_Summary2_name(8,1) = 'surf_avg_omega_div_omega_crit'
+    Text_Summary2_name(9,1) = 'surf_avg_Lrad_div_Ledd'
+    Text_Summary2_name(10,1) = 'center_c12'
+    Text_Summary2_name(11,1) = 'center_o16'
+    Text_Summary2_name(12,1) = ''
+
+    Grid2_plot_name(6) = 'Text_Summary3'
+    Grid2_plot_row(6) =6 
+    Grid2_plot_rowspan(6) = 3
+    Grid2_plot_col(6) = 6
+    Grid2_plot_colspan(6) = 2
+    Grid2_plot_pad_left(6) = 0.0
+    Grid2_plot_pad_right(6) =0.0
+    Grid2_plot_pad_top(6) = 0.05
+    Grid2_plot_pad_bot(6) = 0.0
+    Grid2_txt_scale_factor(6) = 0.14 
+    Text_Summary3_num_rows = 12
+    Text_Summary3_num_cols = 1
+    Text_Summary3_name(:,:) = ''
+
+    Text_Summary3_name(1,1) = 'surf_avg_omega'
+    Text_Summary3_name(2,1) = 'v_surf'
+    Text_Summary3_name(3,1) = 'log_L_div_Ledd'
+    Text_Summary3_name(4,1) = ''
+    Text_Summary3_name(5,1) = ''
+    Text_Summary3_name(6,1) = ''
+    Text_Summary3_name(7,1) = 'surface_he4'
+    Text_Summary3_name(8,1) = 'surface_n14'
+    Text_Summary3_name(9,1) = 'surface_c12'
+    Text_Summary3_name(10,1) = ''
+    Text_Summary3_name(11,1) = ''
+    Text_Summary3_name(12,1) = ''
+        
+
+        
+
+    ! ****************************
+    ! ***** Internal profiles ****
+    ! ****************************
+
+
+    Grid2_plot_name(7) = 'Profile_Panels3'
+    Grid2_plot_row(7) = 0
+    Grid2_plot_rowspan(7) = 7 
+    Grid2_plot_col(7) =8 
+    Grid2_plot_colspan(7) = 4
+    Grid2_plot_pad_left(7) = 0.05
+    Grid2_plot_pad_right(7) = 0.02
+    Grid2_plot_pad_top(7) = 0.07
+    Grid2_plot_pad_bot(7) = 0.0
+    Grid2_txt_scale_factor(7) = 0.5
+    Abundance_legend_txt_scale_factor = 1.0 
+    Power_legend_txt_scale_factor = 1.0 
+
+    Abundance_use_decorator = .false.
+    Abundance_legend_max_cnt = 0
+    !Abundance_xmin = -6
+    Abundance_log_mass_frac_min = -4 ! only used if < 0
+
+    Profile_Panels3_title = 'Abundance-Power-Mixing'
+    Profile_Panels3_xaxis_name = "zone"
+    Profile_Panels3_num_panels = 4
+    Profile_Panels3_txt_scale = 1.0
+    Profile_Panels3_yaxis_name(1) = 'Abundance'
+    Profile_Panels3_yaxis_name(2) = 'Power'
+    Profile_Panels3_yaxis_name(3) = 'Mixing'
+    Profile_Panels3_yaxis_name(4) = 'v_rot'
+    Profile_Panels3_other_yaxis_name(4) = 'omega_div_omega_crit'
+
+    Profile_Panels3_xaxis_reversed = .false.
+    Profile_Panels3_xmin = 0.0 ! only used if /= -101d0
+    ! Profile_Panels3_xmax = 300
+    Power_use_decorator = .true.
+
+    ! ******************************
+    ! ***** History panels *********
+    ! ******************************
+    Grid2_plot_name(8) = 'History_Panels1'
+    History_Panels1_num_panels = 5
+    History_Panels1_yaxis_name(1) = 'lg_wind_mdot_1'
+    History_Panels1_other_yaxis_name(1) = 'lg_mtransfer_rate'
+    History_Panels1_yaxis_name(2) = 'star_mass'
+    History_Panels1_other_yaxis_name(2) = 'envelope_mass'
+    History_Panels1_yaxis_name(3) = 'radius'
+    History_Panels1_other_yaxis_name(3) = 'rl_2'
+    History_Panels1_yaxis_name(4) = 'v_orb_2'
+    History_Panels1_other_yaxis_name(4) = 'period_days'
+    History_Panels1_yaxis_name(5) = 'surface_he4'
+    History_Panels1_other_yaxis_name(5) = 'surface_n14'
+    History_Panels1_xaxis_name = 'model_number'
+    History_Panels1_yaxis_reversed(:) = .false.
+    History_Panels1_yaxis_log(:) = .false.
+     
+    !History_Panels1_ymin(:) = -15d0
+    !History_Panels1_ymax(:) = 0d0
+    History_Panels1_ymargin(:) = 0.5
+    History_Panels1_dymin(:) = -1
+
+    Grid2_plot_row(8) =0
+    Grid2_plot_rowspan(8) =10 
+    Grid2_plot_col(8) = 13 
+    Grid2_plot_colspan(8) = 4 
+    Grid2_plot_pad_left(8) = 0.02
+    Grid2_plot_pad_right(8) = 0.03
+    Grid2_plot_pad_top(8) = 0.07
+    Grid2_plot_pad_bot(8) = 0.05
+    Grid2_txt_scale_factor(8) = 0.5
+
+      
+/ ! end of pgstar namelist
+
+

--- a/step1_InitialModel_Binary/inlist2
+++ b/step1_InitialModel_Binary/inlist2
@@ -67,6 +67,7 @@
 &controls
       zams_filename = './zams_z1.42m2_y0.2703.data' !POSYDON ZAMS files
       initial_z = 1.42d-2
+      initial_y = 2.7029999999999998D-01
 
       warn_when_large_rel_run_E_err = 1d99
       !warn_when_stop_checking_residuals = .false.
@@ -268,3 +269,4 @@ delta_HR_ds_L = 0.125d0
       x_logical_ctrl(3) = .false.
 
 / ! end of controls namelist
+

--- a/step1_InitialModel_Binary/inlist_project
+++ b/step1_InitialModel_Binary/inlist_project
@@ -12,10 +12,18 @@
    m1 = 12.d0
    m2 = 1.4d0
    initial_period_in_days = -1d0
-   initial_separation_in_Rsuns = 972
+   initial_separation_in_Rsuns = 972d0
 
 
-   photo_interval = 0
+   !!! output controls
+   history_interval = 1                           ! interval for writing to binary history;                                   default: 5      | save all steps in history
+   append_to_star_history = .true.                ! define whether the binary history is appended to the star's history, too; default: .true. | allows to plot stellar and binary data from same file
+   photo_interval = 50                            ! interval for writing photos;                                              default: 50     | overwrites value in inlist of the components
+   photo_digits = 5                               ! number of digits in photo's filename;                                     default: 3      | overwrites value in inlist of the components
+   terminal_interval = 10                         ! interval for terminal outputs;                                            default: 1      | get less outputs
+   write_header_frequency = 10                    ! frequency to repeat the header every X outputs;                           default: 10     |
+   extra_binary_terminal_output_file = 'out.txt'  ! writes terminal output to this file, too;  
+   
    do_jdot_mb = .false.
    do_jdot_missing_wind = .true.
    do_j_accretion = .true. ! according to De Mink et al. 2013

--- a/step1_InitialModel_Binary/src/run_binary_extras.f90
+++ b/step1_InitialModel_Binary/src/run_binary_extras.f90
@@ -30,6 +30,10 @@
          use binary_def
          use math_lib !use crlibm_lib
          use utils_lib
+
+         USE, INTRINSIC :: IEEE_ARITHMETIC ! isnan() was not working
+
+
    
          implicit none
    
@@ -446,7 +450,7 @@
                    E2 = exp10(-0.42_dp)*pow(s% r(i)/r_phot,7.5_dp)! H-rich stars
                 !write(*,*) E2, s% r(i)
                 end if
-                if (isnan(E2)) then  !maybe this won't be used.
+                if (IEEE_IS_NAN(E2)) then  !maybe this won't be used.
                     k_div_T = 1d-20
                 else
                    k_div_T = sqrt(standard_cgrav*m*r_phot*r_phot/pow5(osep)/(Msun/pow3(Rsun)))
@@ -575,6 +579,7 @@
             real(dp), dimension (max_num_mixing_regions) :: cz_bot_mass_posydon
             real(dp) :: cz_bot_radius_posydon(max_num_mixing_regions)
             real(dp), dimension (max_num_mixing_regions) :: cz_top_mass_posydon, cz_top_radius_posydon
+
    
             ! k/T computed as in Hurley, J., Tout, C., Pols, O. 2002, MNRAS, 329, 897
             ! Kudos to Francesca Valsecchi for help implementing and testing this
@@ -661,7 +666,7 @@
               end if
            end if
    
-                if (isnan(E2)) then  !maybe this won't be used.
+                if ( IEEE_IS_NAN(E2) ) then  !maybe this won't be used.
                     k_div_T_posydon = 1d-99
                 else
                    k_div_T_posydon = sqrt(standard_cgrav*m*r_phot*r_phot/pow5(osep)/(Msun/pow3(Rsun)))


### PR DESCRIPTION
The inlist files and routines were modified to be compatible with the rf/ion branch of MESA v23.05.1
The HMS+HMS run until overflow from L2 (R_L2) surface for q(=Macc/Mdon)<1, donor is star 1, as termination point.
The enhanced FULLER et al. TAYLER-SPRUIT was tested updated, as well as the get_ion_info function (extracted from mesa commit 270dafb)